### PR TITLE
Include license in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
-include pyfda/fixpoint_widgets/*.png
-include pyfda/fixpoint_widgets/*.svg
-include pyfda/pyfda_log.conf
-include pyfda/pyfda.conf
-include README_PYPI.rst
+recursive-include pyfda *
+
+include AUTHORS.py
+include LICENSE
+include README*.*
+include index.html
+include requirements.txt


### PR DESCRIPTION
The terms of the license requires all copies of the software include the license.  Also include requirements.txt, the authors, and simplify the MANIFEST.in file somewhar.