### PR TITLE
get rid of deprecation warning "Creating an ndarray from ragged nested sequences"

### DIFF
--- a/pyfda/input_widgets/input_pz.py
+++ b/pyfda/input_widgets/input_pz.py
@@ -472,14 +472,18 @@ class Input_PZ(QWidget):
         Load all entries from filter dict fb.fil[0]['zpk'] into the Zero/Pole/Gain list
         self.zpk and update the display via `self._refresh_table()`.
         The explicit np.array( ... ) statement enforces a deep copy of fb.fil[0],
-        otherwise the filter dict would be modified inadvertedly.
+        otherwise the filter dict would be modified inadvertedly. `dtype=object`
+        needs to be specified to create a numpy array from the nested lists with
+        differing lengths without creating the deprecation warning
 
-        The filter dict is a "normal" numpy float array for z / p / k values
-        The ZPK register `self.zpk` should be a list of float ndarrays to allow
-        for different lengths of z / p / k subarrays while adding / deleting items.?
+        "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of
+        lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated."
+
+        The filter dict fb.fil[0]['zpk'] is a list of numpy float ndarrays for z / p / k values
+        `self.zpk` is an array of float ndarrays with different lengths of z / p / k subarrays 
+        to allow adding / deleting items.
         """
-        # TODO: check the above       
-        self.zpk = np.array(fb.fil[0]['zpk'])# this enforces a deep copy
+        self.zpk = np.array(fb.fil[0]['zpk'], dtype=object)# this enforces a deep copy
         qstyle_widget(self.ui.butSave, 'normal')
         self._refresh_table()
 
@@ -524,7 +528,7 @@ class Input_PZ(QWidget):
         Clear & initialize table and zpk for two poles and zeros @ origin,
         P = Z = [0; 0], k = 1
         """
-        self.zpk = np.array([[0, 0], [0, 0], 1])
+        self.zpk = np.array([[0, 0], [0, 0], 1], dtype=object)
         self.Hmax_last = 1.0
         self.anti = False
 

--- a/pyfda/input_widgets/input_pz.py
+++ b/pyfda/input_widgets/input_pz.py
@@ -351,6 +351,7 @@ class Input_PZ(QWidget):
         """
         if self.spec_edited:
             self.zpk[2] = safe_eval(source.text(), alt_expr = str(self.zpk[2]))
+            qstyle_widget(self.ui.butSave, 'changed')
             self.spec_edited = False # reset flag
 
 #------------------------------------------------------------------------------

--- a/pyfda/libs/pyfda_lib.py
+++ b/pyfda/libs/pyfda_lib.py
@@ -1419,11 +1419,8 @@ def fil_convert(fil_dict, format_in):
     Exceptions
     ----------
     ValueError for Nan / Inf elements or other unsuitable parameters
-
     """
-
     if 'sos' in format_in:
-
         # check for bad coeffs before converting IIR filt
         # this is the same defn used by scipy (tolerance of 1e-14)
         if (fil_dict['ft'] == 'IIR'):
@@ -1478,12 +1475,11 @@ def fil_convert(fil_dict, format_in):
     elif 'ba' in format_in: # arg = [b,a]
         b, a = fil_dict['ba'][0], fil_dict['ba'][1]
         if np.all(np.isfinite([b,a])):
-            #try:
-                zpk = sig.tf2zpk(b,a)
-                zpk = np.nan_to_num(zpk)
-                fil_dict['zpk'] = [zpk[0].astype(np.complex), zpk[1].astype(np.complex), zpk[2]]
-            #except Exception as e:
-                #raise ValueError(e)
+            zpk = sig.tf2zpk(b,a)
+            fil_dict['zpk'] = [np.nan_to_num(zpk[0]).astype(np.complex),
+                               np.nan_to_num(zpk[1]).astype(np.complex),
+                               np.nan_to_num(zpk[2])
+                               ]
         else:
             raise ValueError("\t'fil_convert()': Cannot convert coefficients with NaN or Inf elements to zpk format!")
             zpk = None


### PR DESCRIPTION
... by declaring explicitly np.array( some_ragged_list , dtype=object) or by handling the elements of ragged list indidually