### PR TITLE
fix typo Chebychev -> Chebyshev

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Layout and some default paths can be customized using the file `pyfda/pyfda_rc.p
 ### The following features are currently implemented:
 
 * **Filter design**
-    * **Design methods**: Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebychev 1 and 2 (from scipy.signal and custom methods)
+    * **Design methods**: Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebyshev 1 and 2 (from scipy.signal and custom methods)
     * **Second-Order Sections** are used in the filter design when available for more robust filter design and analysis
     * **Remember all specifications** when changing filter design methods
     * **Fine-tune** manually the filter order and corner frequencies calculated by minimum order algorithms

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
 <ul>
 <li>
-<strong>Design methods</strong> from scipy.signal: Equiripple, Firwin, Butterworth, Elliptic, Chebychev 1 and Chebychev 2 </li>
+<strong>Design methods</strong> from scipy.signal: Equiripple, Firwin, Butterworth, Elliptic, Chebyshev 1 and Chebyshev 2 </li>
 <li>
 <strong>Remember all specifications</strong> when changing filter design methods</li>
 <li>

--- a/pyfda/filter_widgets/butter.py
+++ b/pyfda/filter_widgets/butter.py
@@ -108,7 +108,7 @@ class Butter(object):
 have a maximally flat frequency response in the passband and are monotonous 
 in both pass and stop band(s), the step response has only ~4% overshoot 
 . The roll-off is moderately steep, the non-linearity of phase response and 
-group delay are better than with Chebychev and elliptic designs
+group delay are better than with Chebyshev and elliptic designs
 of the same order. Butterworth filters are a good compromise for many applications.
 
 For manual order filter design, only the order :math:`N` and

--- a/pyfda/filter_widgets/cheby1.py
+++ b/pyfda/filter_widgets/cheby1.py
@@ -7,7 +7,7 @@
 # (see file LICENSE in root directory for details)
 
 """
-Design Chebychev 1 filters (LP, HP, BP, BS) with fixed or minimum order, return
+Design Chebyshev 1 filters (LP, HP, BP, BS) with fixed or minimum order, return
 the filter design in zpk (zeros, poles, gain) or second-order sections (sos) format.
 
 Attention:
@@ -41,7 +41,7 @@ from .common import Common
 
 __version__ = "2.2"
 
-classes = {'Cheby1':'Chebychev 1'} #: Dict containing class name : display name
+classes = {'Cheby1':'Chebyshev 1'} #: Dict containing class name : display name
 
 class Cheby1(object):
 
@@ -69,7 +69,7 @@ class Cheby1(object):
             }
 
         self.info = """
-**Chebychev Type 1 filters**
+**Chebyshev Type 1 filters**
 
 maximize the rate of cutoff between the frequency response’s passband and stopband,
 at the expense of passband ripple :math:`A_PB` and increased ringing in
@@ -136,7 +136,7 @@ critical passband frequency :math:`F_C` from passband / stopband specifications.
         design.
         """
         if self.N > 30:
-            return qfilter_warning(None, self.N, "Chebychev 1")
+            return qfilter_warning(None, self.N, "Chebyshev 1")
         else:
             return True
 

--- a/pyfda/filter_widgets/cheby2.py
+++ b/pyfda/filter_widgets/cheby2.py
@@ -7,7 +7,7 @@
 # (see file LICENSE in root directory for details)
 
 """
-Design Chebychev 2 filters (LP, HP, BP, BS) with fixed or minimum order, return
+Design Chebyshev 2 filters (LP, HP, BP, BS) with fixed or minimum order, return
 the filter design in zeros, poles, gain (zpk) or second-order sections (sos) format.
 
 Attention:
@@ -41,7 +41,7 @@ from pyfda.libs.pyfda_qt_lib import qfilter_warning
 
 __version__ = "2.2"
 
-classes = {'Cheby2':'Chebychev 2'} #: Dict containing class name : display name
+classes = {'Cheby2':'Chebyshev 2'} #: Dict containing class name : display name
 
 class Cheby2(object):
 
@@ -134,7 +134,7 @@ critical stop band frequency :math:`F_C` from pass and stop band specifications.
         design.
         """
         if self.N > 25:
-            return qfilter_warning(None, self.N, "Chebychev 2")
+            return qfilter_warning(None, self.N, "Chebyshev 2")
         else:
             return True
 

--- a/pyfda/filter_widgets/ellip.py
+++ b/pyfda/filter_widgets/ellip.py
@@ -54,7 +54,7 @@ class Ellip(object):
 frequency response’s passband and stopband of all IIR filters. This comes
 at the expense of a constant ripple (equiripple) :math:`A_PB` and :math:`A_SB`
 in both pass and stop band. Ringing of the step response is increased in
-comparison to Chebychev filters.
+comparison to Chebyshev filters.
 
 As the passband ripple :math:`A_PB` approaches 0, the elliptical filter becomes
 a Chebyshev type II filter. As the stopband ripple :math:`A_SB` approaches 0,

--- a/pyfda/filter_widgets/ellip_zero.py
+++ b/pyfda/filter_widgets/ellip_zero.py
@@ -56,7 +56,7 @@ class EllipZeroPhz(QWidget):
 frequency response’s passband and stopband of all IIR filters. This comes
 at the expense of a constant ripple (equiripple) :math:`A_PB` and :math:`A_SB`
 in both pass and stop band. Ringing of the step response is increased in
-comparison to Chebychev filters.
+comparison to Chebyshev filters.
  
 As the passband ripple :math:`A_PB` approaches 0, the elliptical filter becomes
 a Chebyshev type II filter. As the stopband ripple :math:`A_SB` approaches 0,

--- a/pyfda/filterbroker.py
+++ b/pyfda/filterbroker.py
@@ -80,8 +80,8 @@ filter_classes = OrderedDict(
     [# IIR
      ('Bessel', {'name': 'Bessel', 'mod': 'pyfda.filter_widgets.bessel'}),
      ('Butter', {'name': 'Butterworth', 'mod': 'pyfda.filter_widgets.butter'}),
-     ('Cheby1', {'name': 'Chebychev 1', 'mod': 'pyfda.filter_widgets.cheby1'}),
-     ('Cheby2', {'name': 'Chebychev 2', 'mod': 'pyfda.filter_widgets.cheby2'}),
+     ('Cheby1', {'name': 'Chebyshev 1', 'mod': 'pyfda.filter_widgets.cheby1'}),
+     ('Cheby2', {'name': 'Chebyshev 2', 'mod': 'pyfda.filter_widgets.cheby2'}),
      ('Ellip', {'name': 'Elliptic', 'mod': 'pyfda.filter_widgets.ellip'}),
      ('EllipZeroPhz', {'name': 'EllipZeroPhz', 'mod': 'pyfda.filter_widgets.ellip_zero'}),
      # FIR

--- a/pyfda/input_widgets/select_filter.py
+++ b/pyfda/input_widgets/select_filter.py
@@ -61,7 +61,7 @@ class SelectFilter(QWidget):
 
         - cmbFilterType for selection of filter type (IIR, FIR, ...)
 
-        - cmbFilterClass for selection of design design class (Chebychev, ...)
+        - cmbFilterClass for selection of design design class (Chebyshev, ...)
 
         and populate them from the "filterTree" dict during the initial run.
         Later, calling _set_response_type() updates the three combo boxes.
@@ -246,7 +246,7 @@ class SelectFilter(QWidget):
         Triggered when cmbFilterType (IIR, FIR, ...) is changed:
         - read filter type ft and copy it to fb.fil[0]['ft'] and self.ft
         - (re)construct design method combo, adding
-          displayed text (e.g. "Chebychev 1") and hidden data (e.g. "cheby1")
+          displayed text (e.g. "Chebyshev 1") and hidden data (e.g. "cheby1")
         """
         # Read out current setting of comboBox and convert to string
         fb.fil[0]['ft'] = self.ft = qget_cmb_box(self.cmbFilterType)

--- a/pyfda/libs/pyfda_fft_windows_lib.py
+++ b/pyfda/libs/pyfda_fft_windows_lib.py
@@ -87,7 +87,7 @@ windows =\
              },
     'Bohman':
         {'fn_name':'bohman'},
-    'Dolph-Chebychev':
+    'Dolph-Chebyshev':
         {'fn_name':'chebwin',
          'par':[{
             'name':'a', 'name_tex':r'$a$',
@@ -96,7 +96,7 @@ windows =\
          'info':
              ('<span>This window optimizes for the narrowest main lobe width for '
               'a given order <i>M</i> and sidelobe equiripple attenuation <i>a</i>, '
-              'using Chebychev polynomials.</span>'),
+              'using Chebyshev polynomials.</span>'),
         },
     'Cosine':
         {'info':

--- a/pyfda/libs/tree_builder.py
+++ b/pyfda/libs/tree_builder.py
@@ -449,7 +449,7 @@ class Tree_Builder(object):
           reading their module level attribute `classes` with classes contained
           in the module.
 
-          `classes` is a dictionary, e.g. `{"Cheby":"Chebychev 1"}` where
+          `classes` is a dictionary, e.g. `{"Cheby":"Chebyshev 1"}` where
           the key is the class name in the module and the value the corresponding
           display name (used for the combo box).
 
@@ -482,7 +482,7 @@ class Tree_Builder(object):
 
         .. code-block:: python
 
-             {'Cheby1':{'name':'Chebychev 1',
+             {'Cheby1':{'name':'Chebyshev 1',
               'mod':'pyfda.filter_design.cheby1',
               'fix': 'IIR_cascade',
               'opt': ["option1", "option2"]}

--- a/recipe/meta.yaml.1_2
+++ b/recipe/meta.yaml.1_2
@@ -67,7 +67,7 @@ about:
     \ ``pyfdax`` and `pyfdax_no_term` are created (with / without terminal).\n\nFor development, you can also run pyFDA using::\n\n    In [1]: %run -m pyfda.pyfdax # IPython or\n    >> python -m pyfda.pyfdax\
     \    # plain python interpreter\n\n    \nor run individual files from pyFDA using e.g.::\n\n    In [2]: %run -m pyfda.input_widgets.input_pz  # IPython or\n    >> python -m pyfda.input_widgets.input_pz\
     \     # plain python interpreter\n   \nCustomization\n-------------\n\nThe layout and some default paths can be customized using the file ``pyfda/pyfda_rc.py``.\n\nFeatures\n--------\n\n* **Filter design**\n\
-    \    * **Design methods**: Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebychev 1 and 2 (from scipy.signal and custom methods)\n    * **Second-Order Sections** are used in the\
+    \    * **Design methods**: Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebyshev 1 and 2 (from scipy.signal and custom methods)\n    * **Second-Order Sections** are used in the\
     \ filter design when available for more robust filter design and analysis\n    * **Remember all specifications** when changing filter design methods\n    * **Fine-tune** manually the filter order and\
     \ corner frequencies calculated by minimum order algorithms\n    * **Compare filter designs** for a given set of specifications and different design methods\n    * **Filter coefficients and poles /\
     \ zeroes** can be displayed, edited and quantized in various formats\n* **Clearly structured User Interface**\n    * only widgets needed for the currently selected design method are visible\n    * enhanced\

--- a/ressource/flatpak/pyfda.appdata.xml
+++ b/ressource/flatpak/pyfda.appdata.xml
@@ -11,7 +11,7 @@
     <ul>
     	<li> <b>Filter design</b>
 			<ul>
-				<li><b>Design methods:</b> Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebychev 1 and 2 (from scipy.signal and custom methods)</li>
+				<li><b>Design methods:</b> Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebyshev 1 and 2 (from scipy.signal and custom methods)</li>
 				<li><b>Second-Order Sections</b> are used in the filter design when available for more robust filter design and analysis</li>
 				<li><b>Remember all specifications</b> when changing filter design methods</li>				
 				<li><b>Fine-tune</b> manually the filter order and corner frequencies calculated by minimum order algorithms</li>


### PR DESCRIPTION
Fixes the spelling from Chebychev to Chebyshev throughout (though not in the screenshots).