### PR TITLE
update appdatafile

### DIFF
--- a/ressource/linux/pyfda.appdata.xml
+++ b/ressource/linux/pyfda.appdata.xml
@@ -89,6 +89,23 @@
   </provides>
 
   <releases>
+  <release version="0.7.1" date="2022-10-05">
+      <description>
+        <p>This release mainly fixes crashes with matplotlib 3.1 and scipy 1.8.0</p>
+      </description>
+    </release>
+    <release version="0.7.0" date="2022-10-04">
+      <description>
+        <p>Fixpoint filters</p>
+        <ul>
+          <li>This release has mainly addressed fixpoint simulation, introducing an IIR DF1 filter.</li>
+          <li>In the y[n] tab, you can now load CSV and WAV files as stimuli.</li>
+          <li>Export of CMSIS DSP coefficients in SOS format is now possible, somewhat hidden in the CSV export options.</li>
+          <li>Lots of bugfixes.</li>
+          <li>Usage of Github actions will ease future releases for hopefully shorter release cycles.</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.1" date="2022-03-27">
       <description>
         <p>This release mainly fixes crashes with matplotlib 3.1 and scipy 1.8.0</p>

--- a/ressource/linux/pyfda.appdata.xml
+++ b/ressource/linux/pyfda.appdata.xml
@@ -70,14 +70,14 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main view</caption>
-        <image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_3.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_3d_4.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_hn.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_scr_shot_baq_impz.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_3d_3.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_pz.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_screenshot_spec_error.png</image>
-		<image>https://github.com/chipmuenk/pyfda/raw/master/img/pyfda_scr_shot_3d5_info.png</image>
+        <image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_3.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_3d_4.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_hn.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_scr_shot_baq_impz.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_3d_3.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_pz.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_screenshot_spec_error.png</image>
+		<image>https://github.com/chipmuenk/pyfda/raw/main/img/pyfda_scr_shot_3d5_info.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
- Update version in the appdata file
Currently changelogs are written down in two places, which makes it quite error prone. At gittyup we are creating from the changelog.md file the xml release information and then we create out of it the appdata file:

for that we are using cmark. cmark creates a html version of the changelog
https://github.com/Murmele/Gittyup/blob/master/src/app/CMakeLists.txt#L42-L50

The html version is then used and placed into the appdata file:
https://github.com/Murmele/Gittyup/blob/master/cmake/generate_appdata.cmake

Just a recomandation for writing the changelog in a single place and distributing it multiple times.

