### PR TITLE
use less complicated feature list in appdata file

### DIFF
--- a/ressource/linux/pyfda.appdata.xml
+++ b/ressource/linux/pyfda.appdata.xml
@@ -9,59 +9,30 @@
   <description>
     <p>Features:</p>
     <ul>
-    	<li> <b>Filter design</b>
-			<ul>
-				<li><b>Design methods:</b> Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebyshev 1 and 2 (from scipy.signal and custom methods)</li>
-				<li><b>Second-Order Sections</b> are used in the filter design when available for more robust filter design and analysis</li>
-				<li><b>Remember all specifications</b> when changing filter design methods</li>				
-				<li><b>Fine-tune</b> manually the filter order and corner frequencies calculated by minimum order algorithms</li>
-				<li><b>Compare filter designs</b> for a given set of specifications and different design methods</li>
-				<li><b>Filter coefficients and poles / zeroes</b> can be displayed, edited and quantized in various formats</li>
-			</ul>
-		</li>
-
-		<li> <b>Clearly structured User Interface</b>
-			<ul>
-				<li>only widgets needed for the currently selected design method are visible</li>
-				<li>enhanced matplotlib NavigationToolbar (nicer icons, additional functions)</li>
-				<li>display help files (own / Python docstrings) as rich text</li>				
-				<li>tooltips for all control and entry widgets</li>
-			</ul>
-		</li>
-
-		<li> <b>Common interface for all filter design methods</b>
-			<ul>
-				<li>specify frequencies as absolute values or normalized to sampling or Nyquist frequency</li>
-				<li>specify ripple and attenuations in dB, as voltage or as power ratios</li>
-				<li>enter expressions like exp(-pi/4 * 1j) with the help of the library simpleeval (included in source files)</li>				
-			</ul>
-		</li>
-
-		<li> <b>Graphical Analyses</b>
-			<ul>
-				<li>Magnitude response (lin / power / log) with optional display of specification bands, phase and an inset plot</li>
-				<li>Phase response (wrapped / unwrapped)</li>
-				<li>Group delay</li>
-				<li>Pole / Zero plot</li>
-				<li>Impulse response and step response (lin / log)</li>
-				<li>3D-Plots (|H(f)|, mesh, surface, contour) with optional pole / zero display</li>				
-			</ul>
-		</li>
-
-		<li> <b>Modular architecture</b>, facilitating the implementation of new filter design and analysis methods 
-			<ul>
-				<li>Filter design files not only contain the actual algorithm but also dictionaries specifying which parameters and standard widgets have to be displayed in the GUI.</li>
-				<li>Special widgets needed by design methods (e.g. for choosing the window type in Firwin) are included in the filter design file, not in the main program</li>			
-			</ul>
-		</li>
-
-		<li> <b>Saving and loading</b>
-			<ul>
-				<li>Save and load filter designs in pickled and in numpy's NPZ-format</li>
-				<li>Export and import coefficients and poles/zeros as comma-separated values (CSV), in numpy's NPY- and NPZ-formats, in Excel (R) or in Matlab (R) workspace format</li>
-				<li>Export coefficients in FPGA vendor specific formats like Xilinx (R) COE-format</li>				
-			</ul>
-		</li>
+		<li>Design methods: Equiripple, Firwin, Moving Average, Bessel, Butterworth, Elliptic, Chebyshev 1 and 2 (from scipy.signal and custom methods)</li>
+		<li>Second-Order Sections are used in the filter design when available for more robust filter design and analysis</li>
+		<li>Remember all specifications when changing filter design methods</li>
+		<li>Fine-tune manually the filter order and corner frequencies calculated by minimum order algorithms</li>
+		<li>Compare filter designs for a given set of specifications and different design methods</li>
+		<li>Filter coefficients and poles / zeroes can be displayed, edited and quantized in various formats</li>
+		<li>only widgets needed for the currently selected design method are visible</li>
+		<li>enhanced matplotlib NavigationToolbar (nicer icons, additional functions)</li>
+		<li>display help files (own / Python docstrings) as rich text</li>
+		<li>tooltips for all control and entry widgets</li>
+		<li>specify frequencies as absolute values or normalized to sampling or Nyquist frequency</li>
+		<li>specify ripple and attenuations in dB, as voltage or as power ratios</li>
+		<li>enter expressions like exp(-pi/4 * 1j) with the help of the library simpleeval (included in source files)</li>
+		<li>Magnitude response (lin / power / log) with optional display of specification bands, phase and an inset plot</li>
+		<li>Phase response (wrapped / unwrapped)</li>
+		<li>Group delay</li>
+		<li>Pole / Zero plot</li>
+		<li>Impulse response and step response (lin / log)</li>
+		<li>3D-Plots (|H(f)|, mesh, surface, contour) with optional pole / zero display</li>
+		<li>Filter design files not only contain the actual algorithm but also dictionaries specifying which parameters and standard widgets have to be displayed in the GUI.</li>
+		<li>Special widgets needed by design methods (e.g. for choosing the window type in Firwin) are included in the filter design file, not in the main program</li>
+		<li>Save and load filter designs in pickled and in numpy's NPZ-format</li>
+		<li>Export and import coefficients and poles/zeros as comma-separated values (CSV), in numpy's NPY- and NPZ-formats, in Excel (R) or in Matlab (R) workspace format</li>
+		<li>Export coefficients in FPGA vendor specific formats like Xilinx (R) COE-format</li>
     </ul>
   </description>
 
@@ -82,6 +53,9 @@
   </screenshots>
 
   <url type="homepage">https://github.com/chipmuenk/pyfda</url>
+  <url type="bugtracker">https://github.com/chipmuenk/pyfda/issues</url>
+  <url type="help">https://github.com/chipmuenk/pyfda/issues</url>
+
 
   <provides>
     <binary>pyfdax</binary>


### PR DESCRIPTION
use less complicated feature list, because the websize does not support capsulated lists

If you don't like the proposal, let me know so we can change it.

Currently on flathub it looks like this:
![grafik](https://user-images.githubusercontent.com/10099533/195020516-89b7f91c-225a-4a6b-b480-652b91c86974.png)

sorry I have overseen this.