### PR TITLE
Use state="highlight" for push buttons instead of built-in "checked" state

### DIFF
--- a/pyfda/filter_widgets/firwin.py
+++ b/pyfda/filter_widgets/firwin.py
@@ -34,7 +34,7 @@ API version info:
    :2.2: Rename `filter_classes` -> `classes`, remove Py2 compatibility
 """
 from pyfda.libs.compat import (QWidget, pyqtSignal, QComboBox, QIcon, QSize,
-                               QPushButton, QHBoxLayout, QVBoxLayout)
+                               QHBoxLayout, QVBoxLayout)
 import copy
 import numpy as np
 import scipy.signal as sig
@@ -44,7 +44,7 @@ from scipy.special import sinc
 import pyfda.filterbroker as fb  # importing filterbroker initializes all its globals
 import pyfda.libs.pyfda_dirs as dirs
 from pyfda.libs.pyfda_lib import fil_save, round_odd, pprint_log
-from pyfda.libs.pyfda_qt_lib import popup_warning, qset_cmb_box
+from pyfda.libs.pyfda_qt_lib import popup_warning, PushButton
 from pyfda.libs.fft_windows_cmb_box import QFFTWinCmbBox
 from pyfda.libs.pyfda_fft_windows_lib import all_wins_dict_ref
 from pyfda.plot_widgets.plot_fft_win import Plot_FFT_win
@@ -185,8 +185,7 @@ class Firwin(QWidget):
         self.win_viewer.hide()
 
         # button for opening FFT window
-        self.but_fft_wdg = QPushButton(self)
-        self.but_fft_wdg.setIcon(QIcon(":/fft.svg"))
+        self.but_fft_wdg = PushButton(self, icon=QIcon(":/fft.svg"))
         but_height = self.qfft_win_select.sizeHint().height()
         self.but_fft_wdg.setIconSize(QSize(but_height, but_height))
         self.but_fft_wdg.setFixedSize(QSize(but_height, but_height))
@@ -582,7 +581,7 @@ class Firwin(QWidget):
         Show / hide FFT widget depending on the state of the corresponding button
         When widget is shown, trigger an update of the window function.
         """
-        if self.but_fft_wdg.isChecked():
+        if self.but_fft_wdg.checked:
             self.win_viewer.show()
             self.emit({'view_changed': 'fft_win_type'}, sig_name='sig_tx_local')
         else:

--- a/pyfda/fixpoint_widgets/fx_ui_wq.py
+++ b/pyfda/fixpoint_widgets/fx_ui_wq.py
@@ -20,11 +20,11 @@ from pyfda.libs.tree_builder import merge_dicts_hierarchically
 import pyfda.libs.pyfda_fix_lib as fx
 
 from pyfda.libs.compat import (
-    Qt, QWidget, QLabel, QLineEdit, QComboBox, QPushButton, QIcon,
+    Qt, QWidget, QLabel, QLineEdit, QComboBox, QIcon,
     QVBoxLayout, QHBoxLayout, QGridLayout, QFrame, pyqtSignal)
 
 from pyfda.libs.pyfda_qt_lib import (
-    qcmb_box_populate, qget_cmb_box, qset_cmb_box, qstyle_widget)
+    qcmb_box_populate, qget_cmb_box, qset_cmb_box, qstyle_widget, PushButton)
 from pyfda.pyfda_rc import params
 from pyfda.libs.pyfda_lib import safe_eval, to_html
 
@@ -227,7 +227,7 @@ class FX_UI_WQ(QWidget):
                 f"""'auto/man' combo box.""")
         self.cmbW.setVisible(ui_dict['cmb_w_vis'] == 'on')
 
-        self.butLock = QPushButton(self)
+        self.butLock = PushButton(self, icon=QIcon(':/lock-locked.svg'))
         self.butLock.setCheckable(True)
         self.butLock.setChecked(False)
         self.butLock.setVisible(ui_dict['lock_vis'] == 'on')
@@ -315,7 +315,7 @@ class FX_UI_WQ(QWidget):
         # use only self.Q.q_dict from here on!!
 
         # initialize button icon
-        self.but_lock_update_icon(self.butLock.isChecked())
+        self.but_lock_update_icon(self.butLock.checked)
 
         # ----------------------------------------------------------------------
         # GLOBAL SIGNALS
@@ -338,12 +338,12 @@ class FX_UI_WQ(QWidget):
         self.update_ovfl_cnt()
 
     # --------------------------------------------------------------------------
-    def but_lock_checked(self, checked: bool) -> None:
+    def but_lock_checked(self) -> None:
         """
         Update the icon of the push button depending on its state (checked or not)
         and fire the signal {'ui_local_changed': 'butLock'}
         """
-        self.but_lock_update_icon(checked)
+        self.but_lock_update_icon(self.butLock.checked)
         self.emit({'sender_name': self.objectName(), 'ui_local_changed': 'butLock'})
 
     # --------------------------------------------------------------------------

--- a/pyfda/input_widgets/freq_units.py
+++ b/pyfda/input_widgets/freq_units.py
@@ -223,7 +223,7 @@ class FreqUnits(QWidget):
         remain unchanged.
         """
 
-        if self.butLock.isChecked():
+        if self.butLock.checked:
             # Lock has been activated, keep displayed frequencies locked
             fb.fil[0]['freq_locked'] = True
             self.butLock.setIcon(QIcon(':/lock-locked.svg'))
@@ -446,8 +446,8 @@ class FreqUnits(QWidget):
         Store sort flag in filter dict and emit 'specs_changed':'f_sort'
         when sort button is checked.
         """
-        fb.fil[0]['freq_specs_sort'] = self.butSort.isChecked()
-        if self.butSort.isChecked():
+        fb.fil[0]['freq_specs_sort'] = self.butSort.checked
+        if self.butSort.checked:
             self.emit({'specs_changed': 'f_sort'})
 
 # ------------------------------------------------------------------------------

--- a/pyfda/input_widgets/input_coeffs.py
+++ b/pyfda/input_widgets/input_coeffs.py
@@ -670,7 +670,7 @@ class Input_Coeffs(QWidget):
         CSV format.
         """
         text = qtable2csv(
-            self.tblCoeff, self.ba, formatted=self.ui.but_format.isChecked())
+            self.tblCoeff, self.ba, formatted=self.ui.but_format.checked)
         if self.ui.load_save_clipboard:
             # clipboard is selected as export target
             fb.clipboard.setText(text)
@@ -714,14 +714,14 @@ class Input_Coeffs(QWidget):
 
         TODO: More checks for swapped row <-> col, single values, wrong data type ...
         """
-        formatted_import = self.ui.but_format.isChecked()
+        formatted_import = self.ui.but_format.checked
 
         # Get data as ndarray of str:
 
         if self.ui.load_save_clipboard:  # data from clipboard
             data_str = file2array(
                 None, None, 'ba', from_clipboard=True,
-                as_str = self.ui.but_format.isChecked())
+                as_str = self.ui.but_format.checked)
         else:  # data from file
             file_name, file_type = select_file(self, title="Import Filter Coefficients", mode="r",
                                     file_types=('csv', 'mat', 'npy', 'npz'))
@@ -731,7 +731,7 @@ class Input_Coeffs(QWidget):
                 data_str = file2array(
                     file_name, file_type, 'ba',
                     from_clipboard=False,
-                    as_str = self.ui.but_format.isChecked())
+                    as_str = self.ui.but_format.checked)
 
         if data_str is None:  # file operation has been aborted or some other error
             logger.info(f"Data was not imported.")

--- a/pyfda/input_widgets/input_coeffs_ui.py
+++ b/pyfda/input_widgets/input_coeffs_ui.py
@@ -342,7 +342,7 @@ class Input_Coeffs_UI(QWidget):
         """
         if dirs.csv_options_handle is None:
             # no handle to the window? Create a new instance
-            if self.but_csv_options.isChecked():
+            if self.but_csv_options.checked:
                 # Important: Handle to window must be class attribute, otherwise it
                 # (and the attached window) is deleted immediately when it goes
                 # out of scope

--- a/pyfda/input_widgets/input_coeffs_ui.py
+++ b/pyfda/input_widgets/input_coeffs_ui.py
@@ -139,7 +139,7 @@ class Input_Coeffs_UI(QWidget):
         q_icon_size = self.but_quant.iconSize()  # <- comment this for manual sizing
         self.but_quant.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 
-        self.but_format = QPushButton(QIcon(':/star.svg'), "", self)
+        self.but_format = PushButton(self, icon=QIcon(':/star.svg'), checked=False)
         self.but_format.setToolTip(
             "<span><b>Formatted Data</b><br><br>"
             "When <b>inactive</b>: Import / export coefficients in float / complex "
@@ -148,7 +148,6 @@ class Input_Coeffs_UI(QWidget):
             "format, i.e. with the selected number of digits in Hex, Binary etc.</span>"
             )
         self.but_format.setIconSize(q_icon_size)
-        self.but_format.setCheckable(True)
 
         # layH_q_frmt = QHBoxLayout()
         # layH_q_frmt.addWidget(self.cmb_qfrmt)
@@ -219,8 +218,7 @@ class Input_Coeffs_UI(QWidget):
         self.butClear.setIconSize(q_icon_size)
         self.butClear.setToolTip("Clear all table entries.")
 
-        self.but_file_clipboard = QPushButton(self)
-        self.but_file_clipboard.setIcon(QIcon(':/clipboard.svg'))
+        self.but_file_clipboard = PushButton(self, icon=QIcon(':/clipboard.svg'), checked=False)
         self.but_file_clipboard.setIconSize(q_icon_size)
         self.but_file_clipboard.setToolTip("Select between file and clipboard import / export.")
 

--- a/pyfda/input_widgets/input_fixpoint_specs.py
+++ b/pyfda/input_widgets/input_fixpoint_specs.py
@@ -143,10 +143,10 @@ class Input_Fixpoint_Specs(QWidget):
                 """
                 fb.fil[0]['fxq']['QI'].update(self.wdg_wq_input.Q.q_dict)
                 if dict_sig['ui_local_changed'] == 'butLock'\
-                        and not self.wdg_wq_input.butLock.isChecked():
+                        and not self.wdg_wq_input.butLock.checked:
                     # butLock was deactivitated, don't do anything
                     return
-                elif self.wdg_wq_input.butLock.isChecked():
+                elif self.wdg_wq_input.butLock.checked:
                     # button lock was activated or wordlength settings have been changed
                     # with active lock -> copy input settings to output
                     fb.fil[0]['fxq']['QO']['WI'] = fb.fil[0]['fxq']['QI']['WI']
@@ -160,7 +160,7 @@ class Input_Fixpoint_Specs(QWidget):
                 """
                 fb.fil[0]['fxq']['QO'].update(self.wdg_wq_output.Q.q_dict)
 
-                if self.wdg_wq_input.butLock.isChecked():
+                if self.wdg_wq_input.butLock.checked:
                     fb.fil[0]['fxq']['QI']['WI'] = fb.fil[0]['fxq']['QO']['WI']
                     fb.fil[0]['fxq']['QI']['WF'] = fb.fil[0]['fxq']['QO']['WF']
             else:

--- a/pyfda/input_widgets/input_info.py
+++ b/pyfda/input_widgets/input_info.py
@@ -84,19 +84,17 @@ class Input_Info(QWidget):
 
         # ============== UI Layout =====================================
         # widget / subwindow for filter infos
-        self.butFiltPerf = PushButton("H(f)")
-        self.butFiltPerf.setChecked(True)
+        self.butFiltPerf = PushButton(self, text="H(f)", checked=True)
         self.butFiltPerf.setToolTip("Display frequency response at test frequencies.")
 
-        self.butDebug = PushButton("Debug")
-        self.butDebug.setChecked(False)
+        self.butDebug = PushButton(self, "Debug", checked=False)
         self.butDebug.setToolTip("Show debugging options.")
 
-        self.butAbout = PushButton("About")  # pop-up "About" window
-        self.butAbout.setCheckable(False)
+        self.butAbout = PushButton(self, "About", checkable=False)  # pop-up "About" window
+        self.butAbout.setToolTip(
+            "<span>Show included modules and their versions.</span>")
 
-        self.butSettings = PushButton("Settings")  #
-        self.butSettings.setChecked(False)
+        self.butSettings = PushButton(self, "Settings", checked=False)
         self.butSettings.setToolTip("Display and set some settings")
 
         layHControls1 = QHBoxLayout()
@@ -105,23 +103,19 @@ class Input_Info(QWidget):
         layHControls1.addWidget(self.butSettings)
         layHControls1.addWidget(self.butDebug)
 
-        self.butDocstring = PushButton("Doc$")
-        self.butDocstring.setChecked(False)
+        self.butDocstring = PushButton(self, "Doc$", checked=False)
         self.butDocstring.setToolTip("Display docstring from python filter method.")
 
-        self.butRichText = PushButton("RTF")
-        self.butRichText.setCheckable(HAS_DOCUTILS)
-        self.butRichText.setChecked(HAS_DOCUTILS)
+        self.butRichText = PushButton(
+            self, "RTF", checkable=HAS_DOCUTILS, checked=HAS_DOCUTILS)
         self.butRichText.setEnabled(HAS_DOCUTILS)
         self.butRichText.setToolTip("Render documentation in Rich Text Format.")
 
-        self.butFiltDict = PushButton("FiltDict")
+        self.butFiltDict = PushButton(self, "FiltDict", checked=False)
         self.butFiltDict.setToolTip("Show filter dictionary for debugging.")
-        self.butFiltDict.setChecked(False)
 
-        self.butFiltTree = PushButton("FiltTree")
+        self.butFiltTree = PushButton(self, "FiltTree", checked=False)
         self.butFiltTree.setToolTip("Show filter tree for debugging.")
-        self.butFiltTree.setChecked(False)
 
         layHControls2 = QHBoxLayout()
         layHControls2.addWidget(self.butDocstring)

--- a/pyfda/input_widgets/input_info.py
+++ b/pyfda/input_widgets/input_info.py
@@ -134,7 +134,7 @@ class Input_Info(QWidget):
 
         self.frmControls2 = QFrame(self)
         self.frmControls2.setLayout(layHControls2)
-        self.frmControls2.setVisible(self.butDebug.isChecked())
+        self.frmControls2.setVisible(self.butDebug.checked)
         self.frmControls2.setContentsMargins(0, 0, 0, 0)
 
         lbl_settings_NFFT = QLabel(to_html("N_FFT =", frmt='bi'), self)
@@ -149,7 +149,7 @@ class Input_Info(QWidget):
 
         self.frmSettings = QFrame(self)
         self.frmSettings.setLayout(layGSettings)
-        self.frmSettings.setVisible(self.butSettings.isChecked())
+        self.frmSettings.setVisible(self.butSettings.checked)
         self.frmSettings.setContentsMargins(0, 0, 0, 0)
 
         layVControls = QVBoxLayout()
@@ -220,14 +220,14 @@ class Input_Info(QWidget):
         """
         Show / hide debug options depending on the state of the debug button
         """
-        self.frmControls2.setVisible(self.butDebug.isChecked())
+        self.frmControls2.setVisible(self.butDebug.checked)
 
 # ------------------------------------------------------------------------------
     def _show_settings(self):
         """
         Show / hide settings options depending on the state of the settings button
         """
-        self.frmSettings.setVisible(self.butSettings.isChecked())
+        self.frmSettings.setVisible(self.butSettings.checked)
 
     def _update_settings_nfft(self):
         """ Update value for self.par1 from QLineEdit Widget"""
@@ -252,7 +252,7 @@ class Input_Info(QWidget):
         Display info from filter design file and docstring
         """
         if hasattr(ff.fil_inst, 'info'):
-            if self.butRichText.isChecked():
+            if self.butRichText.checked:
                 self.txtFiltInfoBox.setText(publish_string(
                     self._clean_doc(ff.fil_inst.info), writer_name='html',
                     settings_overrides={'output_encoding': 'unicode'}))
@@ -261,8 +261,8 @@ class Input_Info(QWidget):
         else:
             self.txtFiltInfoBox.setText("")
 
-        if self.butDocstring.isChecked() and hasattr(ff.fil_inst, 'info_doc'):
-            if self.butRichText.isChecked():
+        if self.butDocstring.checked and hasattr(ff.fil_inst, 'info_doc'):
+            if self.butRichText.checked:
                 self.txtFiltInfoBox.append(
                     '<hr /><b>Python module docstring:</b>\n')
                 for doc in ff.fil_inst.info_doc:
@@ -336,8 +336,8 @@ class Input_Info(QWidget):
             return F_min, H_min, F_max, H_max
         # ------------------------------------------------------------------
 
-        self.tblFiltPerf.setVisible(self.butFiltPerf.isChecked())
-        if self.butFiltPerf.isChecked():
+        self.tblFiltPerf.setVisible(self.butFiltPerf.checked)
+        if self.butFiltPerf.checked:
 
             bb = fb.fil[0]['ba'][0]
             aa = fb.fil[0]['ba'][1]
@@ -499,7 +499,7 @@ class Input_Info(QWidget):
         """
         Print filter dict for debugging
         """
-        self.txtFiltDict.setVisible(self.butFiltDict.isChecked())
+        self.txtFiltDict.setVisible(self.butFiltDict.checked)
 
         fb_sorted = [str(key) + ' : ' + str(fb.fil[0][key])
                      for key in sorted(fb.fil[0].keys())]
@@ -512,7 +512,7 @@ class Input_Info(QWidget):
         """
         Print filter tree for debugging
         """
-        self.txtFiltTree.setVisible(self.butFiltTree.isChecked())
+        self.txtFiltTree.setVisible(self.butFiltTree.checked)
 
         ftree_sorted = ['<b>' + str(key) + ' : ' + '</b>' + str(fb.fil_tree[key])
                         for key in sorted(fb.fil_tree.keys())]

--- a/pyfda/input_widgets/input_info.py
+++ b/pyfda/input_widgets/input_info.py
@@ -14,7 +14,7 @@ import pprint
 import textwrap
 
 from pyfda.libs.compat import (
-    QtGui, QWidget, QFont, QFrame, QPushButton, QLabel, QTableWidget, QTableWidgetItem,
+    QtGui, QWidget, QFont, QFrame, QLabel, QTableWidget, QTableWidgetItem,
     QTextBrowser, QTextCursor, QLineEdit, QVBoxLayout, QHBoxLayout, QGridLayout,
     QSplitter, Qt, pyqtSignal)
 

--- a/pyfda/input_widgets/input_pz.py
+++ b/pyfda/input_widgets/input_pz.py
@@ -825,7 +825,7 @@ class Input_PZ(QWidget):
         or to file using a selected format
         """
         text = qtable2csv(
-            self.tblPZ, self.zpk, zpk=True, formatted=self.ui.but_format.isChecked())
+            self.tblPZ, self.zpk, zpk=True, formatted=self.ui.but_format.checked)
         if self.ui.load_save_clipboard:  # data to clipboard:
             fb.clipboard.setText(text)
         else:
@@ -843,7 +843,7 @@ class Input_PZ(QWidget):
         if self.ui.load_save_clipboard:  # data from clipboard
             data_str = file2array(
                 "", "", 'zpk', from_clipboard=True,
-                as_str = self.ui.but_format.isChecked())
+                as_str = self.ui.but_format.checked)
         else:  # data from file
             file_name, file_type = select_file(self, title="Import Poles / Zeros", mode="r",
                                     file_types=('csv', 'mat', 'npy', 'npz'))
@@ -853,7 +853,7 @@ class Input_PZ(QWidget):
                 data_str = file2array(
                     file_name, file_type, 'zpk',
                     from_clipboard=False,
-                    as_str = self.ui.but_format.isChecked())
+                    as_str = self.ui.but_format.checked)
 
         if data_str is None:  # file operation has been aborted
             return

--- a/pyfda/input_widgets/input_pz_ui.py
+++ b/pyfda/input_widgets/input_pz_ui.py
@@ -14,7 +14,7 @@ from pyfda.libs.compat import (
     pyqtSignal, Qt, QWidget, QLabel, QLineEdit, QComboBox, QPushButton,
     QFrame, QSpinBox, QFont, QIcon, QVBoxLayout, QHBoxLayout)
 
-from pyfda.libs.pyfda_qt_lib import qstyle_widget, qcmb_box_populate
+from pyfda.libs.pyfda_qt_lib import qstyle_widget, qcmb_box_populate, PushButton
 from pyfda.libs.csv_option_box import CSV_option_box
 from pyfda.libs.pyfda_lib import to_html, first_item
 import pyfda.libs.pyfda_dirs as dirs
@@ -114,7 +114,7 @@ class Input_PZ_UI(QWidget):
         self.lblDigits = QLabel("Digits", self)
         self.lblDigits.setFont(self.bifont)
 
-        self.but_format = QPushButton(QIcon(':/star.svg'), "", self)
+        self.but_format = PushButton(self, icon=QIcon(':/star.svg'), checked=False)
         self.but_format.setToolTip(
             "<span><b>Formatted Data</b><br><br>"
             "When <b>inactive</b>: Import / export poles, zeros and gain <i>k</i> "
@@ -123,7 +123,6 @@ class Input_PZ_UI(QWidget):
             "coordinates with the selected number of digits etc.</span>"
             )
         q_icon_size = self.but_format.iconSize()
-        self.but_format.setCheckable(True)
 
         # self.cmbCausal = QComboBox(self)
         # causal_types = ['Causal', 'Acausal', 'Anticausal']
@@ -205,8 +204,7 @@ class Input_PZ_UI(QWidget):
         self.butClear.setIconSize(q_icon_size)
         self.butClear.setToolTip("Clear all table entries.")
 
-        self.but_file_clipboard = QPushButton(self)
-        self.but_file_clipboard.setIcon(QIcon(':/clipboard.svg'))
+        self.but_file_clipboard = PushButton(self, icon=QIcon(':/clipboard.svg'), checked=False)
         self.but_file_clipboard.setIconSize(q_icon_size)
         self.but_file_clipboard.setToolTip("Select between file and clipboard import / export.")
 
@@ -228,14 +226,12 @@ class Input_PZ_UI(QWidget):
             "forma with full precision.<br>"
             "Otherwise, export as displayed.</span>")
 
-        self.but_csv_options = QPushButton(self)
-        self.but_csv_options.setIcon(QIcon(':/csv_options.svg'))
+        self.but_csv_options = PushButton(self, icon=QIcon(':/csv_options.svg'), checked=False)
+        # self.but_csv_options.setIcon(QIcon(':/csv_options.svg'))
         self.but_csv_options.setIconSize(q_icon_size)
         self.but_csv_options.setToolTip(
             "<span>Select CSV format and whether "
             "to copy to/from clipboard or file.</span>")
-        self.but_csv_options.setCheckable(True)
-        self.but_csv_options.setChecked(False)
 
         self.load_save_clipboard = not self.load_save_clipboard  # is inverted next step
         self._set_load_save_icons()  # initialize icon / button settings
@@ -307,7 +303,7 @@ class Input_PZ_UI(QWidget):
         """
         if dirs.csv_options_handle is None:
             # no handle to the window? Create a new instance!
-            if self.but_csv_options.isChecked():
+            if self.but_csv_options.checked:
                 # Important: Handle to window must be class attribute otherwise it (and
                 # the attached window) is deleted immediately when it goes out of scope
                 dirs.csv_options_handle = CSV_option_box(self)

--- a/pyfda/input_widgets/weight_specs.py
+++ b/pyfda/input_widgets/weight_specs.py
@@ -12,12 +12,12 @@ Widget for entering weight specifications
 import sys
 
 from pyfda.libs.compat import (
-    QtCore, QWidget, QLabel, QLineEdit, QFrame, QFont, QToolButton,
+    QtCore, QWidget, QLabel, QLineEdit, QFrame, QFont,
     QVBoxLayout, QHBoxLayout, QGridLayout, pyqtSignal, QEvent)
 
 import pyfda.filterbroker as fb
 from pyfda.libs.pyfda_lib import to_html, safe_eval, pprint_log, first_item
-from pyfda.libs.pyfda_qt_lib import qstyle_widget
+from pyfda.libs.pyfda_qt_lib import qstyle_widget, PushButton
 from pyfda.pyfda_rc import params  # FMT string for QLineEdit fields, e.g. '{:.3g}'
 
 import logging
@@ -75,8 +75,8 @@ class WeightSpecs(QWidget):
         lblTitle.setFont(bfont)
         lblTitle.setWordWrap(True)
 
-        self.butReset = QToolButton(self)
-        self.butReset.setText("Reset")
+        self.butReset = PushButton(self, text="Reset", checkable=False)
+        # self.butReset.setText("Reset")
         self.butReset.setToolTip("Reset weights to 1")
 
         layHTitle = QHBoxLayout()       # Layout for title and reset button

--- a/pyfda/libs/compat.py
+++ b/pyfda/libs/compat.py
@@ -88,58 +88,58 @@ from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as Navigatio
 #         return self.getSaveFileName(**kwarg)
 
 
-class QPushButtonRT(QPushButton):
-    """
-    Subclass QPushButton using QLabel to render rich text
-    """
-    def __init__(self, parent=None, text=None, margin=10, **kwargs):
-        if parent is not None:
-            super().__init__(parent, **kwargs)
-        else:
-            super().__init__(**kwargs)
-        self.__lbl = QLabel(self)
-        self.margin = margin
-        if text is not None:
-            self.__lbl.setText(text)
-        self.__lyt = QHBoxLayout()
-        self.__lyt.setContentsMargins(margin, 0, 0, 0)  # L, T, R, B
-        self.__lyt.setSpacing(0)
-        self.setLayout(self.__lyt)
-        # Make QLabel transparent except for painted pixels
-        self.__lbl.setAttribute(Qt.WA_TranslucentBackground)
-        # Disable the delivery of mouse events to the QLabel widget and its children,
-        self.__lbl.setAttribute(Qt.WA_TransparentForMouseEvents)
-        self.__lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.__lbl.setTextFormat(Qt.RichText)
-        self.__lyt.addWidget(self.__lbl, Qt.AlignHCenter)
-        return
+# class QPushButtonRT(QPushButton):
+#     """
+#     Subclass QPushButton using QLabel to render rich text
+#     """
+#     def __init__(self, parent=None, text=None, margin=10, **kwargs):
+#         if parent is not None:
+#             super().__init__(parent, **kwargs)
+#         else:
+#             super().__init__(**kwargs)
+#         self.__lbl = QLabel(self)
+#         self.margin = margin
+#         if text is not None:
+#             self.__lbl.setText(text)
+#         self.__lyt = QHBoxLayout()
+#         self.__lyt.setContentsMargins(margin, 0, 0, 0)  # L, T, R, B
+#         self.__lyt.setSpacing(0)
+#         self.setLayout(self.__lyt)
+#         # Make QLabel transparent except for painted pixels
+#         self.__lbl.setAttribute(Qt.WA_TranslucentBackground)
+#         # Disable the delivery of mouse events to the QLabel widget and its children,
+#         self.__lbl.setAttribute(Qt.WA_TransparentForMouseEvents)
+#         self.__lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+#         self.__lbl.setTextFormat(Qt.RichText)
+#         self.__lyt.addWidget(self.__lbl, Qt.AlignHCenter)
+#         return
 
-    def setText(self, text):
-        self.__lbl.setText(text)
-        self.updateGeometry()
-        return
+#     def setText(self, text):
+#         self.__lbl.setText(text)
+#         self.updateGeometry()
+#         return
 
-    def sizeHint(self):
-        is_checked = self.isChecked()
-        self.setChecked(False)  # always base sizeHint on unchecked state
-        s = QPushButton.sizeHint(self)
-        w = self.__lbl.sizeHint()
-        s.setWidth(w.width() + 2 * self.margin)
-        # s.setHeight(w.height())
-        self.setChecked(is_checked)
-        return s
+#     def sizeHint(self):
+#         is_checked = self.isChecked()
+#         self.setChecked(False)  # always base sizeHint on unchecked state
+#         s = QPushButton.sizeHint(self)
+#         w = self.__lbl.sizeHint()
+#         s.setWidth(w.width() + 2 * self.margin)
+#         # s.setHeight(w.height())
+#         self.setChecked(is_checked)
+#         return s
 
-    # def clicked(self):
-    #     if self.isChecked():
-    #         self.__lbl.setText("chk!")
-    #     self.updateGeometry()
-    #     return
+#     # def clicked(self):
+#     #     if self.isChecked():
+#     #         self.__lbl.setText("chk!")
+#     #     self.updateGeometry()
+#     #     return
 
-    # def paintEvent(self, pe):
-    #     o = QStyleOption()
-    #     o.initFrom(self)
-    #     p = QPainter(self)
-    #     self.style().drawPrimitive(QStyle.PE_Widget, o, p, self)
+#     # def paintEvent(self, pe):
+#     #     o = QStyleOption()
+#     #     o.initFrom(self)
+#     #     p = QPainter(self)
+#     #     self.style().drawPrimitive(QStyle.PE_Widget, o, p, self)
 
 
 if __name__ == '__main__':

--- a/pyfda/libs/pyfda_qt_lib.py
+++ b/pyfda/libs/pyfda_qt_lib.py
@@ -754,7 +754,7 @@ class PushButton(QPushButton):
 
     def eventFilter(self, source, event):
         if event.type() == QEvent.MouseButtonPress:
-            if self._checkable and event.button() == Qt.LeftButton:
+            if self.isEnabled() and self._checkable and event.button() == Qt.LeftButton:
                 # signal is passed to base class where "self.toggle()" is performed
                 self.checked = not self.checked
                 self.style_button()

--- a/pyfda/libs/pyfda_qt_lib.py
+++ b/pyfda/libs/pyfda_qt_lib.py
@@ -717,7 +717,14 @@ class PushButton(QPushButton):
 
         self.setObjectName(objectName)
         self.setCheckable(checkable)
-        self.setChecked(checked)
+        self._checkable = checkable
+        if self._checkable:
+            self.setChecked(checked)
+            self.checked = checked
+        else:
+            self.setChecked(False)
+            self.checked = False           
+
         self.style_button()
 
         self.installEventFilter(self)
@@ -732,25 +739,33 @@ class PushButton(QPushButton):
             self.w = super(PushButton, self).sizeHint().width()
             self.h = super(PushButton, self).sizeHint().height()
 
+    def setChecked(self, checked: bool):
+        if self._checkable:
+            self.checked = checked
+            # self.setChecked(checked)
+            self.style_button()
+
+    def setCheckable(self, checkable: bool):
+        self._checkable = checkable
+        if not self._checkable:
+            self.setChecked(False)
+            self.checked = False
+            self.style_button()        
+
     def eventFilter(self, source, event):
         if event.type() == QEvent.MouseButtonPress:
-            if event.button() == Qt.LeftButton:
-                logger.warning("left!")
-                # self.toggle()  # toggle checked state
-                # signal is passed to base class where "toggle" is performed
-                # -> logic is inverted here!
+            if self._checkable and event.button() == Qt.LeftButton:
+                # signal is passed to base class where "self.toggle()" is performed
+                self.checked = not self.checked
                 self.style_button()
         # Call base class method to continue normal event processing:
         return super(PushButton, self).eventFilter(source, event)
 
     def style_button(self):
-        if self.isChecked():
-            # logger.warning("checked")
-            qstyle_widget(self, "normal")
-        else:
+        if self.checked:
             qstyle_widget(self, "highlight")
-
-
+        else:
+            qstyle_widget(self, "normal")
 
     def sizeHint(self) -> QtCore.QSize:
         return QSize(self.w, self.h)

--- a/pyfda/libs/pyfda_qt_lib.py
+++ b/pyfda/libs/pyfda_qt_lib.py
@@ -717,11 +717,14 @@ class PushButton(QPushButton):
         Whether initial state is checked
     """
 
-    def __init__(self, text: str = "", icon: QIcon = None, N_x: int = 8,
+    def __init__(self, parent=None, text: str = "", icon: QIcon = None, N_x: int = 8,
                  checkable: bool = True, checked: bool = False,
                  objectName="", **kwargs):
 
-        super().__init__(**kwargs)
+        if parent is not None:
+            super().__init__(parent, **kwargs)
+        else:
+            super().__init__(**kwargs)
 
         self.setObjectName(objectName)
 

--- a/pyfda/libs/pyfda_qt_lib.py
+++ b/pyfda/libs/pyfda_qt_lib.py
@@ -846,6 +846,11 @@ class PushButtonRT(QPushButton):
 
         self.installEventFilter(self)
 
+    def setText(self, text):
+        self.lbl_rtf.setText(text)
+        self.updateGeometry()
+        return
+
     def setChecked(self, checked: bool):
         if self._checkable:
             self.checked = checked

--- a/pyfda/plot_widgets/plot_3d.py
+++ b/pyfda/plot_widgets/plot_3d.py
@@ -103,14 +103,14 @@ class Plot_3D(QWidget):
         self.ledBottom.setText(str(self.zmin))
         self.ledBottom.setToolTip("Minimum display value.")
         self.lblBottomdB = QLabel("dB", self)
-        self.lblBottomdB.setVisible(self.but_log.isChecked())
+        self.lblBottomdB.setVisible(self.but_log.checked)
 
         self.lblTop = QLabel(to_html("Top =", frmt='bi'), self)
         self.ledTop = QLineEdit(self, objectName="ledTop")
         self.ledTop.setText(str(self.zmax))
         self.ledTop.setToolTip("Maximum display value.")
         self.lblTopdB = QLabel("dB", self)
-        self.lblTopdB.setVisible(self.but_log.isChecked())
+        self.lblTopdB.setVisible(self.but_log.checked)
 
         self.plt_UC = PushButton("UC", objectName="plt_UC")
         self.plt_UC.setChecked(True)
@@ -281,7 +281,7 @@ class Plot_3D(QWidget):
         dx = (self.xmax - self.xmin) / steps
         dy = (self.ymax - self.ymin) / steps  # grid size cartesian range
 
-        if self.but_plot_in_UC.isChecked():  # Plot circular range in 3D-Plot
+        if self.but_plot_in_UC.checked:  # Plot circular range in 3D-Plot
             [r, phi] = np.meshgrid(np.arange(rmin, rmax, dr),
                                    np.linspace(0, 2 * pi, steps, endpoint=True))
             self.x = r * cos(phi)
@@ -355,7 +355,7 @@ class Plot_3D(QWidget):
         Update min / max settings when lineEdits have been edited
         """
         if self.sender().objectName() == 'but_log':  # clicking but_log triggered the slot
-            if self.but_log.isChecked():
+            if self.but_log.checked:
                 self.ledBottom.setText(str(self.zmin_dB))
                 self.zmax_dB = np.round(20 * log10(self.zmax), 2)
                 self.ledTop.setText(str(self.zmax_dB))
@@ -369,7 +369,7 @@ class Plot_3D(QWidget):
                 self.lblBottomdB.setVisible(False)
 
         else:  # finishing a lineEdit field triggered the slot
-            if self.but_log.isChecked():
+            if self.but_log.checked:
                 self.zmin_dB = safe_eval(
                     self.ledBottom.text(), self.zmin_dB, return_type='float')
                 self.ledBottom.setText(str(self.zmin_dB))
@@ -412,7 +412,7 @@ class Plot_3D(QWidget):
         alpha = self.diaAlpha.value()/10.
 
         cmap = colormaps[str(self.cmbColormap.currentText())]
-        if self.but_colormap_r.isChecked():
+        if self.but_colormap_r.checked:
             cmap = cmap.reversed()  # use reversed colormap
 
         # Number of Lines /step size for H(f) stride, mesh, contour3d:
@@ -420,12 +420,12 @@ class Plot_3D(QWidget):
         NL = 3 * self.diaHatch.value() + 5
 
         surf_enabled = qget_cmb_box(self.cmbMode3D, data=False) in {'Surf', 'Contour'}\
-            or self.but_contour_2d.isChecked()
+            or self.but_contour_2d.checked
         self.cmbColormap.setEnabled(surf_enabled)
         self.but_colormap_r.setEnabled(surf_enabled)
         self.but_lighting.setEnabled(surf_enabled)
         self.but_colbar.setEnabled(surf_enabled)
-        self.diaAlpha.setEnabled(surf_enabled or self.but_contour_2d.isChecked())
+        self.diaAlpha.setEnabled(surf_enabled or self.but_contour_2d.checked)
 
         # cNorm  = colors.Normalize(vmin=0, vmax=values[-1])
         # scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=jet)
@@ -447,7 +447,7 @@ class Plot_3D(QWidget):
         plevel_rel = 1.05  # height of plotted pole position relative to zmax
         zlevel_rel = 0.1  # height of plotted zero position relative to zmax
 
-        if self.but_log.isChecked():  # logarithmic scale
+        if self.but_log.checked:  # logarithmic scale
             # suppress "divide by zero in log10" warnings
             old_settings_seterr = np.seterr()
             np.seterr(divide='ignore')
@@ -486,13 +486,13 @@ class Plot_3D(QWidget):
 
         # calculate H(jw)| along the unity circle and |H(z)|, each clipped
         # between bottom and top
-        H_UC = H_mag(bb, aa, self.xy_UC, top, H_min=bottom, log=self.but_log.isChecked())
-        Hmag = H_mag(bb, aa, self.z, top, H_min=bottom, log=self.but_log.isChecked())
+        H_UC = H_mag(bb, aa, self.xy_UC, top, H_min=bottom, log=self.but_log.checked)
+        Hmag = H_mag(bb, aa, self.z, top, H_min=bottom, log=self.but_log.checked)
 
         # ===============================================================
         # Plot Unit Circle (UC)
         # ===============================================================
-        if self.plt_UC.isChecked():
+        if self.plt_UC.checked:
             #  Plot unit circle and marker at (1,0):
             self.ax3d.plot(self.xy_UC.real, self.xy_UC.imag,
                            ones(len(self.xy_UC)) * bottom, lw=2, color='k')
@@ -501,7 +501,7 @@ class Plot_3D(QWidget):
         # ===============================================================
         # Plot ||H(f)| along unit circle as 3D-lineplot
         # ===============================================================
-        if self.but_Hf.isChecked():
+        if self.but_Hf.checked:
             self.ax3d.plot(self.xy_UC.real, self.xy_UC.imag, H_UC, alpha=0.8, lw=4)
             # draw once more as dashed white line to improve visibility
             self.ax3d.plot(self.xy_UC.real, self.xy_UC.imag, H_UC, 'w--', lw=4)
@@ -517,7 +517,7 @@ class Plot_3D(QWidget):
         # ===============================================================
         # Plot Poles and Zeros
         # ===============================================================
-        if self.but_PZ.isChecked():
+        if self.but_PZ.checked:
 
             PN_SIZE = 8  # size of P/N symbols
 
@@ -570,7 +570,7 @@ class Plot_3D(QWidget):
                 mlab.show()
 
             else:
-                if self.but_lighting.isChecked():
+                if self.but_lighting.checked:
                     ls = LightSource(azdeg=0, altdeg=65)  # Create light source object
                     rgb = ls.shade(Hmag, cmap=cmap)  # Shade data, creating an rgb array
                     cmap_surf = None
@@ -600,7 +600,7 @@ class Plot_3D(QWidget):
         #       along the other axis?
         # TODO: colormap is created depending on the zdir = 'z' contour plot
         #       -> set limits of (all) other plots manually?
-        if self.but_contour_2d.isChecked():
+        if self.but_contour_2d.checked:
 #            self.ax3d.contourf(x, y, Hmag, 20, zdir='x', offset=xmin,
 #                         cmap=cmap, alpha = alpha)#, vmin = bottom)#, vmax = top, vmin = bottom)
 #            self.ax3d.contourf(x, y, Hmag, 20, zdir='y', offset=ymax,
@@ -610,7 +610,7 @@ class Plot_3D(QWidget):
                 cmap=cmap, alpha=alpha)
 
         # plot colorbar for suitable plot modes
-        if self.but_colbar.isChecked() and (self.but_contour_2d.isChecked() or
+        if self.but_colbar.checked and (self.but_contour_2d.checked or
                                             str(self.cmbMode3D.currentText())
                                             in {'Contour', 'Surf'}):
             self.colb = self.mplwidget.fig.colorbar(m_cb, ax=self.ax3d, shrink=0.8, 

--- a/pyfda/plot_widgets/plot_3d.py
+++ b/pyfda/plot_widgets/plot_3d.py
@@ -91,11 +91,11 @@ class Plot_3D(QWidget):
 
 # ------------------------------------------------------------------------------
     def _construct_UI(self):
-        self.but_log = PushButton("dB", objectName="but_log")
+        self.but_log = PushButton(self, "dB", objectName="but_log")
         self.but_log.setToolTip("Logarithmic scale")
 
-        self.but_plot_in_UC = PushButton("|z| < 1 ", objectName="but_plot_in_UC")
-        self.but_plot_in_UC.setChecked(True)
+        self.but_plot_in_UC = PushButton(self, "|z| < 1 ", checked=True,
+                                         objectName="but_plot_in_UC")
         self.but_plot_in_UC.setToolTip("Only plot H(z) within the unit circle")
 
         self.lblBottom = QLabel(to_html("Bottom =", frmt='bi'), self)
@@ -112,15 +112,15 @@ class Plot_3D(QWidget):
         self.lblTopdB = QLabel("dB", self)
         self.lblTopdB.setVisible(self.but_log.checked)
 
-        self.plt_UC = PushButton("UC", objectName="plt_UC")
+        self.plt_UC = PushButton(self, "UC", objectName="plt_UC")
         self.plt_UC.setChecked(True)
         self.plt_UC.setToolTip("Plot unit circle")
 
-        self.but_PZ = PushButton("P/Z ", objectName="but_PZ")
+        self.but_PZ = PushButton(self, "P/Z ", objectName="but_PZ")
         self.but_PZ.setChecked(True)
         self.but_PZ.setToolTip("Plot poles and zeros")
 
-        self.but_Hf = PushButton("H(f) ", objectName="but_Hf")
+        self.but_Hf = PushButton(self, "H(f) ", objectName="but_Hf")
         self.but_Hf.setChecked(True)
         self.but_Hf.setToolTip("Plot H(f) along the unit circle")
 
@@ -131,7 +131,7 @@ class Plot_3D(QWidget):
         self.cmbMode3D.setCurrentIndex(0)
         self.cmbMode3D.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
-        self.but_colormap_r = PushButton("reverse", objectName="but_colormap_r")
+        self.but_colormap_r = PushButton(self, "reverse", objectName="but_colormap_r")
         self.but_colormap_r.setChecked(True)
         self.but_colormap_r.setToolTip("reverse colormap")
 
@@ -139,10 +139,10 @@ class Plot_3D(QWidget):
         self._init_cmb_colormap(cmap_init=self.cmap_default)
         self.cmbColormap.setToolTip("Select colormap")
 
-        self.but_colbar = PushButton("Colorbar ", objectName="chkColBar")
+        self.but_colbar = PushButton(self, "Colorbar ", objectName="chkColBar")
         self.but_colbar.setToolTip("Show colorbar")
 
-        self.but_lighting = PushButton("Lighting", objectName="but_lighting")
+        self.but_lighting = PushButton(self, "Lighting", objectName="but_lighting")
         self.but_lighting.setToolTip("Enable light source")
 
         self.lblAlpha = QLabel(to_html("Alpha", frmt='bi'), self)
@@ -165,7 +165,7 @@ class Plot_3D(QWidget):
         self.diaHatch.setWrapping(False)
         self.diaHatch.setToolTip("Set line density for various plots.")
 
-        self.but_contour_2d = PushButton("Contour2D ", objectName="chkContour2D")
+        self.but_contour_2d = PushButton(self, "Contour2D ", objectName="chkContour2D")
         self.but_contour_2d.setToolTip("Plot 2D-contours at z =0")
 
         # ----------------------------------------------------------------------

--- a/pyfda/plot_widgets/plot_fft_win.py
+++ b/pyfda/plot_widgets/plot_fft_win.py
@@ -229,14 +229,14 @@ class Plot_FFT_win(QDialog):
         self.but_log_t.setToolTip("Display in dB")
 
         self.led_log_bottom_t = QLineEdit(self)
-        self.led_log_bottom_t.setVisible(self.but_log_t.isChecked())
+        self.led_log_bottom_t.setVisible(self.but_log_t.checked)
         self.led_log_bottom_t.setText(str(self.bottom_t))
         self.led_log_bottom_t.setMaximumWidth(qtext_width(N_x=6))
         self.led_log_bottom_t.setToolTip(
             "<span>Minimum display value for log. scale.</span>")
 
         self.lbl_log_bottom_t = QLabel(to_html("min =", frmt='bi'), self)
-        self.lbl_log_bottom_t.setVisible(self.but_log_t.isChecked())
+        self.lbl_log_bottom_t.setVisible(self.but_log_t.checked)
 
         self.lbl_title_freq = QLabel("Freq: ", objectName="medium")
         self.but_norm_f = PushButton("Max=1", default=False, autoDefault=False)
@@ -260,10 +260,10 @@ class Plot_FFT_win(QDialog):
         self.but_log_f.setChecked(True)
 
         self.lbl_log_bottom_f = QLabel(to_html("min =", frmt='bi'), self)
-        self.lbl_log_bottom_f.setVisible(self.but_log_f.isChecked())
+        self.lbl_log_bottom_f.setVisible(self.but_log_f.checked)
 
         self.led_log_bottom_f = QLineEdit(self)
-        self.led_log_bottom_f.setVisible(self.but_log_t.isChecked())
+        self.led_log_bottom_f.setVisible(self.but_log_t.checked)
         self.led_log_bottom_f.setText(str(self.bottom_f))
         self.led_log_bottom_f.setMaximumWidth(qtext_width(N_x=6))
         self.led_log_bottom_f.setToolTip(
@@ -547,7 +547,7 @@ class Plot_FFT_win(QDialog):
         self.max_a_err = self.Win[self.pad // 2] / (self.N_view * self.cgain)
 
         # Correct gain for periodic signals (coherent gain)
-        if self.but_norm_f.isChecked():
+        if self.but_norm_f.checked:
             self.Win /= (self.N_view * self.cgain)
 
         # calculate frequency of first zero and maximum sidelobe level,
@@ -636,13 +636,13 @@ class Plot_FFT_win(QDialog):
         self.ax_f.set_xlabel(fb.fil[0]['plt_fLabel'])
         self.ax_f.set_ylabel(r'$W(f) \; \rightarrow$')
 
-        if self.but_log_t.isChecked():
+        if self.but_log_t.checked:
             self.ax_t.plot(self.n, np.maximum(20 * np.log10(np.abs(self.win_view)),
                                               self.bottom_t))
         else:
             self.ax_t.plot(self.n, self.win_view)
 
-        if self.but_half_f.isChecked():
+        if self.but_half_f.checked:
             F = self.F[:len(self.F*self.pad)//2]
             k = self.k[:len(self.F*self.pad)//2]
             Win = self.Win[:len(self.F*self.pad)//2]
@@ -674,7 +674,7 @@ class Plot_FFT_win(QDialog):
             self.mainlobe_3dB_disp = self.mainlobe_3dB_freq
             self.mainlobe_3dB_unit = "f_S"
 
-        if self.but_log_f.isChecked():
+        if self.but_log_f.checked:
             self.ax_f.plot(x, np.maximum(
                 20 * np.log10(np.abs(Win)), self.bottom_f))
 
@@ -693,10 +693,10 @@ class Plot_FFT_win(QDialog):
             self.max_a_err_unit = "%"
 
 
-        self.led_log_bottom_t.setVisible(self.but_log_t.isChecked())
-        self.lbl_log_bottom_t.setVisible(self.but_log_t.isChecked())
-        self.led_log_bottom_f.setVisible(self.but_log_f.isChecked())
-        self.lbl_log_bottom_f.setVisible(self.but_log_f.isChecked())
+        self.led_log_bottom_t.setVisible(self.but_log_t.checked)
+        self.lbl_log_bottom_t.setVisible(self.but_log_t.checked)
+        self.led_log_bottom_f.setVisible(self.but_log_f.checked)
+        self.lbl_log_bottom_f.setVisible(self.but_log_f.checked)
 
         cur_id = self.cur_win_dict['id']
         cur_win_d = self.all_wins_dict[cur_id]

--- a/pyfda/plot_widgets/plot_fft_win.py
+++ b/pyfda/plot_widgets/plot_fft_win.py
@@ -18,7 +18,7 @@ import matplotlib.patches as mpl_patches
 
 from pyfda.libs.pyfda_lib import safe_eval, to_html, pprint_log
 from pyfda.libs.pyfda_qt_lib import (
-    qwindow_stay_on_top, qtext_width, QVLine, QHLine, PushButton)
+    qwindow_stay_on_top, qtext_width, QVLine, QHLine, PushButton, PushButtonRT)
 from pyfda.libs.fft_windows_cmb_box import QFFTWinCmbBox
 from pyfda.plot_widgets.mpl_widget import MplWidget
 
@@ -26,7 +26,7 @@ from pyfda.plot_widgets.mpl_widget import MplWidget
 import pyfda.filterbroker as fb
 
 from pyfda.libs.compat import (
-    Qt, pyqtSignal, QHBoxLayout, QVBoxLayout, QDialog, QLabel, QLineEdit, QPushButtonRT,
+    Qt, pyqtSignal, QHBoxLayout, QVBoxLayout, QDialog, QLabel, QLineEdit,
     QFrame, QFont, QTextBrowser, QSplitter, QTableWidget, QTableWidgetItem,
     QSizePolicy, QHeaderView)
 import logging
@@ -269,8 +269,8 @@ class Plot_FFT_win(QDialog):
         self.led_log_bottom_f.setToolTip(
             "<span>Minimum display value for log. scale.</span>")
 
-        self.but_bin_f = QPushButtonRT(self, "<b>&Delta; <i>f</i></b>", margin=5,
-                                       objectName="but_bin_f")
+        self.but_bin_f = PushButtonRT(
+            self, text="<b>&Delta; <i>f</i></b>", margin=5, objectName="but_bin_f")
         self.but_bin_f.setMaximumWidth(qtext_width(" bins "))
         self.but_bin_f.setToolTip(
             "<span>Display frequencies in bins or multiples of &Delta;<i>f = f<sub>S </sub>/N</i>."
@@ -651,7 +651,7 @@ class Plot_FFT_win(QDialog):
             k = fftshift(self.k)
             Win = fftshift(self.Win)
 
-        if self.but_bin_f.isChecked():
+        if self.but_bin_f.checked:
             self.ax_f.set_xlabel(r"$k \; \rightarrow$")
             x = k
 

--- a/pyfda/plot_widgets/plot_fft_win.py
+++ b/pyfda/plot_widgets/plot_fft_win.py
@@ -223,7 +223,7 @@ class Plot_FFT_win(QDialog):
         # By default, the enter key triggers the default 'dialog action' in QDialog
         # widgets. This would activate one of the pushbuttons if `default` wasn't False.
         self.lbl_title_time = QLabel("Time: ", objectName="medium")
-        self.but_log_t = PushButton("dB", default=False, autoDefault=False,
+        self.but_log_t = PushButton(self, "dB", default=False, autoDefault=False,
                                      objectName="chk_log_time")
         self.but_log_t.setMaximumWidth(qtext_width(" dB "))
         self.but_log_t.setToolTip("Display in dB")
@@ -239,13 +239,13 @@ class Plot_FFT_win(QDialog):
         self.lbl_log_bottom_t.setVisible(self.but_log_t.checked)
 
         self.lbl_title_freq = QLabel("Freq: ", objectName="medium")
-        self.but_norm_f = PushButton("Max=1", default=False, autoDefault=False)
+        self.but_norm_f = PushButton(self, "Max=1", default=False, autoDefault=False)
         self.but_norm_f.setChecked(True)
         self.but_norm_f.setMaximumWidth(qtext_width(text=" Max=1 "))
         self.but_norm_f.setToolTip(
             "Normalize window spectrum for a maximum of 1.")
 
-        self.but_half_f = PushButton("0...½", default=False, autoDefault=False)
+        self.but_half_f = PushButton(self, "0...½", default=False, autoDefault=False)
         self.but_half_f.setChecked(True)
         self.but_half_f.setMaximumWidth(qtext_width(text=" 0...½ "))
         self.but_half_f.setToolTip(
@@ -253,7 +253,7 @@ class Plot_FFT_win(QDialog):
 
         # By default, the enter key triggers the default 'dialog action' in QDialog
         # widgets. This activates one of the pushbuttons.
-        self.but_log_f = PushButton("dB", default=False, autoDefault=False,
+        self.but_log_f = PushButton(self, "dB", default=False, autoDefault=False,
                                      objectName="chk_log_freq")
         self.but_log_f.setMaximumWidth(qtext_width(" dB "))
         self.but_log_f.setToolTip("<span>Display in dB.</span>")

--- a/pyfda/plot_widgets/plot_hf.py
+++ b/pyfda/plot_widgets/plot_hf.py
@@ -94,7 +94,7 @@ class Plot_Hf(QWidget):
         """
         Define and construct the subwidgets
         """
-        self.lbl_show_H_abs = QLabel(to_html('| H | ', frmt='b'))
+        self.lbl_show_H_abs = QLabel(to_html('| H |', frmt='b'))
         self.chk_show_H_abs = QCheckBox(self)
         self.chk_show_H_abs.setChecked(True)
         self.chk_show_H_abs.setToolTip("Show magnitude of H(F)")
@@ -131,7 +131,7 @@ class Plot_Hf(QWidget):
 
         self.cmb_units_a.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
-        self.but_zerophase = PushButton(" Zero phase ")
+        self.but_zerophase = PushButton(self, "Zero Phase")
         self.but_zerophase.setToolTip(
             "<span>Subtract linear phase as calculated from filter order. "
             "Only available for FIR filters and for unit 'V', it "
@@ -144,13 +144,13 @@ class Plot_Hf(QWidget):
         self.cmbInset.setCurrentIndex(0)
         self.inset_idx = 0  # store previous index for comparison
 
-        self.but_specs = PushButton("Specs ")
+        self.but_specs = PushButton(self, "Specs")
         self.but_specs.setToolTip("Display filter specs as hatched regions")
 
-        self.but_phase = PushButton("Phase ")
+        self.but_phase = PushButton(self, "Phase")
         self.but_phase.setToolTip("Overlay phase")
 
-        self.but_align = PushButton("Align")
+        self.but_align = PushButton(self, "Align")
         self.but_align.setToolTip(
             "<span>Try to align gridlines for magnitude and phase "
             "(doesn't work in all cases).</span>")

--- a/pyfda/plot_widgets/plot_hf.py
+++ b/pyfda/plot_widgets/plot_hf.py
@@ -154,7 +154,7 @@ class Plot_Hf(QWidget):
         self.but_align.setToolTip(
             "<span>Try to align gridlines for magnitude and phase "
             "(doesn't work in all cases).</span>")
-        self.but_align.setVisible(self.but_phase.isChecked())
+        self.but_align.setVisible(self.but_phase.checked)
 
         # ----------------------------------------------------------------------
         #               ### frmControls ###
@@ -523,7 +523,7 @@ class Plot_Hf(QWidget):
             if self.cmbInset.currentIndex() == 1: # edit / navigate inset
                 self.ax_i.set_navigate(True)
                 self.ax.set_navigate(False)
-                if self.but_specs.isChecked():
+                if self.but_specs.checked:
                     self.plot_spec_limits(self.ax_i)
             else: # edit / navigate main plot
                 self.ax_i.set_navigate(False)
@@ -552,7 +552,7 @@ class Plot_Hf(QWidget):
         # except (KeyError, AttributeError):
         #     pass
 
-        if self.but_phase.isChecked():
+        if self.but_phase.checked:
             self.ax_p = ax.twinx()  # second axes system with same x-axis for phase
             self.ax_p.is_twin = True  # mark this as 'twin' to suppress second grid in mpl_widget
 #
@@ -591,7 +591,7 @@ class Plot_Hf(QWidget):
         r"""
         Re-calculate \|H(f)\| and draw the figure
         """
-        self.but_align.setVisible(self.but_phase.isChecked())
+        self.but_align.setVisible(self.but_phase.checked)
         self.calc_hf()
         self.update_view()
 
@@ -643,7 +643,7 @@ class Plot_Hf(QWidget):
         self.but_zerophase.setCheckable(self.unitA == 'V')
         self.but_zerophase.setEnabled(self.unitA == 'V')
 
-        self.specs = self.but_specs.isChecked()
+        self.specs = self.but_specs.checked
 
         self.f_max = get_fil_dict(['f_max'])
 
@@ -674,7 +674,7 @@ class Plot_Hf(QWidget):
             self.H_c = self.H_cmplx
 
         # remove linear phase if button is checked
-        if self.but_zerophase.isChecked():
+        if self.but_zerophase.checked:
             self.H_c = self.H_c * np.exp(1j * self.W[0:len(self.F)] * get_fil_dict(["N"])/2.)
 
         H_str = r'$H(\mathrm{e}^{\mathrm{j} \Omega})$'
@@ -740,7 +740,7 @@ class Plot_Hf(QWidget):
             #-----------------------------------------------------------
 
             #============= Set Limits and draw specs =========================
-            if self.but_specs.isChecked():
+            if self.but_specs.checked:
                 self.plot_spec_limits(self.ax)
 
             #     self.ax_bounds = [self.ax.get_ybound()[0], self.ax.get_ybound()[1]]#, self.ax.get]
@@ -756,7 +756,7 @@ class Plot_Hf(QWidget):
                 title_str = "Magnitude "
             elif self.chk_show_H_re.isChecked() or self.chk_show_H_im.isChecked():
                 title_str = "Amplitude "
-            if self.but_phase.isChecked():
+            if self.but_phase.checked:
                 if title_str != "":
                     title_str += "and Phase "
                 else:
@@ -786,7 +786,7 @@ class Plot_Hf(QWidget):
         """
         Redraw the canvas when e.g. the canvas size has changed
         """
-        if hasattr(self, 'ax_p') and self.but_align.isChecked():
+        if hasattr(self, 'ax_p') and self.but_align.checked:
             # Align gridlines between H(f) and phi nicely
             self.align_y_axes(self.ax, self.ax_p)
         self.mplwidget.redraw()

--- a/pyfda/plot_widgets/plot_impz.py
+++ b/pyfda/plot_widgets/plot_impz.py
@@ -1031,8 +1031,8 @@ class Plot_Impz(QWidget):
         else:
             self.ui.but_log_spgr_time.setEnabled(True)
 
-        log = self.ui.but_log_time.isChecked() or\
-            (self.ui.but_log_spgr_time.isChecked() and self.spgr)
+        log = self.ui.but_log_time.checked or\
+            (self.ui.but_log_spgr_time.checked and self.spgr)
         self.ui.lbl_log_bottom_time.setVisible(log)
         self.ui.led_log_bottom_time.setVisible(log)
         if log:
@@ -1049,7 +1049,7 @@ class Plot_Impz(QWidget):
         self.ui.bottom_f
         """
 
-        log = self.ui.but_log_freq.isChecked()
+        log = self.ui.but_log_freq.checked
         self.ui.lbl_log_bottom_freq.setVisible(log)
         self.ui.led_log_bottom_freq.setVisible(log)
         if log:
@@ -1211,7 +1211,7 @@ class Plot_Impz(QWidget):
         # fixpoint simulation enabled -> assign frame to x_q
         if fb.fil[0]['fx_sim'] and hasattr(self, 'x_q'):
             x_q = self.x_q[self.ui.N_start:N_end]
-            if self.ui.but_log_time.isChecked():
+            if self.ui.but_log_time.checked:
                 x_q = np.maximum(20 * np.log10(abs(x_q)), self.ui.bottom_t)
         else:
             x_q = None
@@ -1253,7 +1253,7 @@ class Plot_Impz(QWidget):
         lbl_x_r_interp = "$x(t)$"
 
         # log. scale for stimulus / response time domain:
-        if self.ui.but_log_time.isChecked():
+        if self.ui.but_log_time.checked:
             bottom_t = self.ui.bottom_t
 
             x_r = np.maximum(20 * np.log10(abs(x_r)), self.ui.bottom_t)
@@ -1325,7 +1325,7 @@ class Plot_Impz(QWidget):
             l_r += [lbl_y_r]
         # --------------- Window plot ----------------------------------
         if self.ui.chk_win_time.isChecked():
-            if self.ui.but_log_time.isChecked():
+            if self.ui.but_log_time.checked:
                 win = np.maximum(
                     20 * np.log10(abs(self.ui.qfft_win_select.calc_window(self.ui.N))),
                     self.ui.bottom_t)
@@ -1417,7 +1417,7 @@ class Plot_Impz(QWidget):
             dB_scale = 20  # default log scale for magnitude in dB
             spgr_unit = r" in W / Hz"  # default unit for spectrogram
             scaling = "density"  # default scaling for spectrogram
-            if self.ui.but_log_spgr_time.isChecked():
+            if self.ui.but_log_spgr_time.checked:
                 dB_unit = "dB"
             else:
                 dB_unit = ""
@@ -1427,7 +1427,7 @@ class Plot_Impz(QWidget):
 
                 if self.ui.chk_byfs_spgr_time.isChecked():
                     # display result scaled by f_S
-                    if self.ui.but_log_spgr_time.isChecked():
+                    if self.ui.but_log_spgr_time.checked:
                         spgr_unit = r" in dB re W / Hz"
                     else:
                         spgr_unit = r" in W / Hz"
@@ -1454,7 +1454,7 @@ class Plot_Impz(QWidget):
                 mode = "psd"
 
             # ------- lin / log ----------------------
-            if self.ui.but_log_spgr_time.isChecked():
+            if self.ui.but_log_spgr_time.checked:
                 scale = 'dB'
                 # 10 log10 for 'psd', otherwise 20 log10
                 bottom_spgr = self.ui.bottom_t
@@ -1506,7 +1506,7 @@ class Plot_Impz(QWidget):
     #                           np.fft.fftshift(Sxx, axes=0), shading='gouraud')
                 # self.ax_s.colorbar(col_mesh)
 
-                if self.ui.but_log_spgr_time.isChecked():
+                if self.ui.but_log_spgr_time.checked:
                     Sxx = np.maximum(dB_scale * np.log10(np.abs(Sxx)), self.ui.bottom_t)
                 # shading: 'auto', 'gouraud', 'nearest'
                 col_mesh = self.ax_s.pcolormesh(t, f, Sxx, shading='auto')
@@ -1558,7 +1558,7 @@ class Plot_Impz(QWidget):
             or self.plt_freq_stmq != "none"\
             or self.plt_freq_resp != "none"
 
-        # if not self.ui.but_log_freq.isChecked() \
+        # if not self.ui.but_log_freq.checked \
         # and len(self.mplwidget_f.fig.get_axes()) == 2:
         # get rid of second axis when returning from log mode by clearing all
         #    self.mplwidget_f.fig.clear()
@@ -1577,7 +1577,7 @@ class Plot_Impz(QWidget):
         # for ax in self.axes_f:
         #    ax.cla()
 
-        if self.ui.but_log_freq.isChecked():
+        if self.ui.but_log_freq.checked:
             # and len(self.mplwidget_f.fig.get_axes()) == 1:??
             # create second axis scaled for noise power scale if it doesn't exist yet
             self.ax_f1_noise = self.ax_f1.twinx()
@@ -1765,7 +1765,7 @@ class Plot_Impz(QWidget):
             # -----------------------------------------------------------------
             # Calculate log FFT and power if selected, set units
             # -----------------------------------------------------------------
-            if self.ui.but_log_freq.isChecked():
+            if self.ui.but_log_freq.checked:
                 unit = " in dBV"
                 unit_P = "dBW"
                 H_F_pre = "|"
@@ -1878,7 +1878,7 @@ class Plot_Impz(QWidget):
             # -----------------------------------------------------------------
             # --------------- Plot stimuli and response -----------------------
             # -----------------------------------------------------------------
-            show_info = self.ui.but_freq_show_info.isChecked()
+            show_info = self.ui.but_freq_show_info.checked
             h_r = []  # plot handles (real / mag. part)
             h_i = []  # plot handles (imag. / phase part)
             l_r = []  # labels (real / mag. part)
@@ -2036,7 +2036,7 @@ class Plot_Impz(QWidget):
             self.ax_f1.set_xlim(F_range)
             self.ax_f1.set_title("Spectrum of " + self.title_str)
 
-            if self.ui.but_log_freq.isChecked():
+            if self.ui.but_log_freq.checked:
                 # scale second axis for noise power
                 corr = 10*np.log10(self.ui.N) - nenbw  # nenbw is in dB
                 mn, mx = self.ax_f1.get_ylim()

--- a/pyfda/plot_widgets/plot_impz.py
+++ b/pyfda/plot_widgets/plot_impz.py
@@ -530,10 +530,10 @@ class Plot_Impz(QWidget):
         Triggered when checkbox "Autorun" is clicked or specs have been edited,
         requiring a recalculation.
 
-        When Autorun has been pushed (`but_auto_run.isChecked() == True`) and
+        When Autorun has been pushed (`but_auto_run.checked == True`) and
         calculation is required, automatically run `impz_init()`.
         """
-        if self.ui.but_auto_run.isChecked() and self.needs_calc:
+        if self.ui.but_auto_run.checked and self.needs_calc:
             self.impz_init()
 
     # --------------------------------------------------------------------------
@@ -591,7 +591,7 @@ class Plot_Impz(QWidget):
 
         if type(arg) == bool:
             self.needs_calc = True  # but_run has been pressed -> force run
-        elif not self.ui.but_auto_run.isChecked():  # "Auto" is not active, return
+        elif not self.ui.but_auto_run.checked:  # "Auto" is not active, return
             return
 
         if self.needs_calc:

--- a/pyfda/plot_widgets/plot_impz.py
+++ b/pyfda/plot_widgets/plot_impz.py
@@ -234,8 +234,8 @@ class Plot_Impz(QWidget):
         self.ui.led_time_ovlp_spgr.editingFinished.connect(self._spgr_ui2params)
         self.ui.cmb_mode_spgr_time.currentIndexChanged.connect(self.draw)
         self.ui.chk_byfs_spgr_time.clicked.connect(self.draw)
-        self.ui.but_fx_range_x.clicked.connect(self.draw)
-        self.ui.but_fx_range_y.clicked.connect(self.draw)
+        self.ui.chk_fx_range_x.clicked.connect(self.draw)
+        self.ui.chk_fx_range_y.clicked.connect(self.draw)
         self.ui.chk_win_time.clicked.connect(self.draw)
         # --- frequency domain plotting ---------------------------------------
         self.ui.cmb_plt_freq_resp.currentIndexChanged.connect(self.draw)
@@ -849,8 +849,8 @@ class Plot_Impz(QWidget):
         self.ui.cmb_plt_time_stmq.setVisible(fx_mode)  # cmb box time domain
         self.ui.lbl_plt_time_stmq.setVisible(fx_mode)  # cmb box time domain
         self.ui.lbl_fx_range.setVisible(fx_mode)  # display fx range limits
-        self.ui.but_fx_range_x.setVisible(fx_mode)  # display fx range limits
-        self.ui.but_fx_range_y.setVisible(fx_mode)  # display fx range limits
+        self.ui.chk_fx_range_x.setVisible(fx_mode)  # display fx range limits
+        self.ui.chk_fx_range_y.setVisible(fx_mode)  # display fx range limits
 
         # add / delete fixpoint entry to / from spectrogram combo box and set
         # `fx_str = "fixpoint"`` or `""``
@@ -1281,10 +1281,10 @@ class Plot_Impz(QWidget):
             else:
                 H_str = H_str + ' in V'
 
-        if self.ui.but_fx_range_x.isChecked() and fb.fil[0]['fx_sim']:
+        if self.ui.chk_fx_range_x.isChecked() and fb.fil[0]['fx_sim']:
             self.ax_r.axhline(fx_max_x, 0, 1, linestyle='--')
             self.ax_r.axhline(fx_min_x, 0, 1, linestyle='--')
-        if self.ui.but_fx_range_y.isChecked() and fb.fil[0]['fx_sim']:
+        if self.ui.chk_fx_range_y.isChecked() and fb.fil[0]['fx_sim']:
             self.ax_r.axhline(fx_max_y, 0, 1, linestyle='-.')
             self.ax_r.axhline(fx_min_y, 0, 1, linestyle='-.')
 

--- a/pyfda/plot_widgets/plot_impz.py
+++ b/pyfda/plot_widgets/plot_impz.py
@@ -255,7 +255,7 @@ class Plot_Impz(QWidget):
         """
         Toggle setting of index_k button in filterbroker, update frequency scaling and call `draw()`
         """
-        fb.fil[0]["tab_yn"]["display_index_k"] = self.ui.but_freq_index_k.isChecked()
+        fb.fil[0]["tab_yn"]["display_index_k"] = self.ui.but_freq_index_k.checked
         self.stim_wdg.ui.normalize_freqs()
         self.draw()
 # ------------------------------------------------------------------------------
@@ -1632,20 +1632,20 @@ class Plot_Impz(QWidget):
 
         H_F_str = ""
         ejO_str = r"$(\mathrm{e}^{\mathrm{j} \Omega})$"
-        if self.plt_freq_enabled or self.ui.but_Hf.isChecked():
+        if self.plt_freq_enabled or self.ui.but_Hf.checked:
             if plt_stimulus:
                 H_F_str += r'$X$, '
             if plt_stimulus_q:
                 H_F_str += r'$X_Q$, '
             if plt_response:
                 H_F_str += r'$Y$, '
-            if self.ui.but_Hf.isChecked():
+            if self.ui.but_Hf.checked:
                 H_F_str += r'$H_{id}$, '
             H_F_str = H_F_str.rstrip(', ') + ejO_str
 
             F_range = fb.fil[0]['freqSpecsRange']
 
-            if self.ui.but_freq_index_k.isChecked():
+            if self.ui.but_freq_index_k.checked:
                 """
                 "'<i>k</i>' specifies frequencies w.r.t. " + to_html("f_S", frmt = 'i') +
                 " but plots graphs over the frequency index <i>k</i>.</span>",
@@ -1675,7 +1675,7 @@ class Plot_Impz(QWidget):
         # - Scale impulse response with N_FFT to calculate frequency response if requested
             if self.ui.but_freq_norm_impz.isVisible()\
                 and self.ui.but_freq_norm_impz.isEnabled()\
-                    and self.ui.but_freq_norm_impz.isChecked():
+                    and self.ui.but_freq_norm_impz.checked:
                 freq_resp = True  # calculate frequency response from impulse response
                 scale_impz = self.ui.N * self.ui.all_wins_dict['cgain']\
                     * self.stim_wdg.ui.scale_impz
@@ -1806,7 +1806,7 @@ class Plot_Impz(QWidget):
                         if self.en_mag_phi_f:
                             Y_i = angle_zero(Y)
 
-                if self.ui.but_Hf.isChecked():
+                if self.ui.but_Hf.checked:
                     if self.en_re_im_f:
                         H_id_r = np.maximum(20 * np.log10(np.abs(H_id.real)),
                                             self.ui.bottom_f)
@@ -1847,7 +1847,7 @@ class Plot_Impz(QWidget):
                         if self.en_mag_phi_f:
                             Y_i = angle_zero(Y)
 
-                if self.ui.but_Hf.isChecked():
+                if self.ui.but_Hf.checked:
                     if self.en_re_im_f:
                         H_id_r = H_id.real
                         H_id_i = H_id.imag
@@ -1888,7 +1888,7 @@ class Plot_Impz(QWidget):
             lbl_empty = "        "
 
             # -------------------- Plot H_id ----------------------------------
-            if self.ui.but_Hf.isChecked():
+            if self.ui.but_Hf.checked:
                 label_re = "$|H_{id}$" + ejO_str + "|"
                 if self.en_re_im_f:
                     label_re = "$H_{id,r}$" + ejO_str
@@ -1994,7 +1994,7 @@ class Plot_Impz(QWidget):
 
             # --------------- LEGEND (real part) ----------------------------------
             # The legend will fill the first column, then the next from top to bottom etc.
-            if self.plt_freq_enabled or self.ui.but_Hf.isChecked():
+            if self.plt_freq_enabled or self.ui.but_Hf.checked:
 
                 # labels = np.concatenate([labels, [r"$NENBW$:"], ["{0:.4g} {1}"\
                 # .format(nenbw, unit_nenbw)], [r"$CGAIN$:", "{0:.4g} {1}".format(nenbw,
@@ -2027,7 +2027,7 @@ class Plot_Impz(QWidget):
                                   framealpha=0.7)
                 self.ax_f2.set_ylabel(H_Fi_str)
 
-            if self.ui.but_freq_index_k.isChecked():
+            if self.ui.but_freq_index_k.checked:
                 self.axes_f[-1].set_xlabel(r'$k \; \rightarrow$')
             else:
                 self.axes_f[-1].set_xlabel(fb.fil[0]['plt_fLabel'])

--- a/pyfda/plot_widgets/plot_impz.py
+++ b/pyfda/plot_widgets/plot_impz.py
@@ -772,7 +772,7 @@ class Plot_Impz(QWidget):
         """
         # step error calculation: calculate system DC response and subtract it
         # from the response
-        if self.stim_wdg.ui.stim == "step" and self.stim_wdg.ui.chk_step_err.isChecked():
+        if self.stim_wdg.ui.stim == "step" and self.stim_wdg.ui.but_step_err.checked:
             if len(self.sos) > 0:  # has second order sections
                 dc = sig.sosfreqz(self.sos, [0])  # yields (w(0), H(0))
             else:

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -179,9 +179,7 @@ class PlotImpz_UI(QWidget):
 
         but_height = self.but_auto_run.sizeHint().height()
 
-        self.but_run = QPushButton(self)
-        self.but_run.setIcon(QIcon(":/play.svg"))
-
+        self.but_run = PushButton(self, icon=QIcon(":/play.svg"))
         self.but_run.setIconSize(QSize(but_height, but_height))
         self.but_run.setFixedSize(QSize(2 * but_height, but_height))
         self.but_run.setToolTip("Run simulation")
@@ -244,8 +242,7 @@ class PlotImpz_UI(QWidget):
         self.lbl_stim_cmplx_warn.setStyleSheet("background-color : yellow;"
                                                "border : 1px solid grey")
 
-        self.but_fft_wdg = QPushButton(self)
-        self.but_fft_wdg.setIcon(QIcon(":/fft.svg"))
+        self.but_fft_wdg = PushButton(self, icon=QIcon(":/fft.svg"))
         self.but_fft_wdg.setIconSize(QSize(but_height, but_height))
         self.but_fft_wdg.setFixedSize(QSize(int(1.5 * but_height), but_height))
         self.but_fft_wdg.setToolTip('<span>Show / hide FFT widget (select window type '

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -202,7 +202,8 @@ class PlotImpz_UI(QWidget):
         self.led_N_start.setToolTip("<span>First point to plot.</span>")
         self.led_N_start.setMaximumWidth(qtext_width(N_x=8))
 
-        self.but_N_auto = QPushButtonRT(self, to_html("N =", frmt="bi"), margin=5)
+        # self.but_N_auto = QPushButtonRT(self, to_html("N =", frmt="bi"), margin=5)
+        self.but_N_auto = PushButton(to_html("N =", frmt="bi"), rtf=True, margin=5)
         self.but_N_auto.setCheckable(True)
         self.but_N_auto.setChecked(True)
         self.but_N_auto.setToolTip(

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -10,7 +10,7 @@
 Create the UI for the PlotImz class
 """
 from pyfda.libs.compat import (
-    QCheckBox, QWidget, QComboBox, QLineEdit, QLabel, QPushButton, QPushButtonRT,
+    QCheckBox, QWidget, QComboBox, QLineEdit, QLabel,
     QIcon, QProgressBar, pyqtSignal, QSize, QFrame,
     QHBoxLayout, QVBoxLayout, QGridLayout)
 
@@ -19,7 +19,7 @@ from pyfda.libs.pyfda_sig_lib import impz_len
 import pyfda.filterbroker as fb
 import pyfda.libs.pyfda_dirs as dirs
 from pyfda.libs.pyfda_qt_lib import (
-    qcmb_box_populate, qtext_width, QVLine, PushButton)
+    qcmb_box_populate, qtext_width, QVLine, PushButton, PushButtonRT)
 from pyfda.libs.fft_windows_cmb_box import QFFTWinCmbBox
 # FMT string for QLineEdit fields, e.g. '{:.3g}'
 from pyfda.pyfda_rc import params
@@ -202,8 +202,7 @@ class PlotImpz_UI(QWidget):
         self.led_N_start.setToolTip("<span>First point to plot.</span>")
         self.led_N_start.setMaximumWidth(qtext_width(N_x=8))
 
-        # self.but_N_auto = QPushButtonRT(self, to_html("N =", frmt="bi"), margin=5)
-        self.but_N_auto = PushButton(to_html("N =", frmt="bi"), rtf=True, margin=5)
+        self.but_N_auto = PushButtonRT(self, text = to_html("N =", frmt="bi"), margin=5)
         self.but_N_auto.setCheckable(True)
         self.but_N_auto.setChecked(True)
         self.but_N_auto.setToolTip(
@@ -217,7 +216,7 @@ class PlotImpz_UI(QWidget):
             "Disable <b><i>N</i> =</b> for manual entry.</span>")
         self.led_N_points.setMaximumWidth(qtext_width(N_x=8))
         # Enable entry field only for manual mode
-        self.led_N_points.setEnabled(not self.but_N_auto.isChecked())
+        self.led_N_points.setEnabled(not self.but_N_auto.checked)
 
         self.lbl_N_frame = QLabel(to_html("N_Frame", frmt='bi') + " =", self)
         self.lbl_N_frame.setVisible(False)
@@ -529,15 +528,15 @@ class PlotImpz_UI(QWidget):
         qcmb_box_populate(self.cmb_freq_display, self.cmb_freq_display_items,
                           self.cmb_freq_display_item)
 
-        self.but_Hf = QPushButtonRT(self, to_html("H_id", frmt="bi"), margin=5)
-        self.but_Hf.setObjectName("chk_Hf")
+        self.but_Hf = PushButtonRT(self, to_html("H_id", frmt="bi"), margin=5,
+                                   objectName="chk_Hf")
         self.but_Hf.setToolTip("<span>Show ideal frequency response, calculated "
                                "from the filter coefficients.</span>")
         self.but_Hf.setChecked(False)
         self.but_Hf.setCheckable(True)
 
-        self.but_freq_norm_impz = QPushButtonRT(text="<b><i>E<sub>X</sub></i> = 1</b>",
-                                                margin=5)
+        self.but_freq_norm_impz = PushButtonRT(
+            self, text="<b><i>E<sub>X</sub></i> = 1</b>", margin=5)
         self.but_freq_norm_impz.setToolTip(
             "<span>Normalize the FFT of an impulse stimulus with <i>N<sub>FFT</sub></i> "
             "to an energy <i>E<sub>X</sub></i> = 1. For a dirac pulse, this yields "
@@ -552,7 +551,7 @@ class PlotImpz_UI(QWidget):
             "<span>Show signal power in legend.</span>")
         self.but_freq_show_info.setChecked(False)
 
-        self.but_freq_index_k = QPushButtonRT(text=" <i>k</i> ", objectName="but_show_index_k")
+        self.but_freq_index_k = PushButtonRT(self, text = " <i>k</i> ", objectName="but_show_index_k")
         self.but_freq_index_k.setToolTip(
             "<span>Show FFT indices instead of frequencies.</span>")
         self.but_freq_index_k.setCheckable(True)
@@ -629,7 +628,7 @@ class PlotImpz_UI(QWidget):
 
     # -------------------------------------------------------------------------
     def update_N_auto(self):
-        if not self.but_N_auto.isChecked():
+        if not self.but_N_auto.checked:
             # manual entry of number of data points, enable data entry and return
             self.led_N_points.setEnabled(True)
             return
@@ -686,7 +685,7 @@ class PlotImpz_UI(QWidget):
             # calculate number of data points to be plotted
             self.N = self.N_end - self.N_start
         else:
-            if self.but_N_auto.isChecked():  # automatic calculation
+            if self.but_N_auto.checked:  # automatic calculation
                 self.N = impz_len(fb.fil[0]['ba'], level=-40)
 
             # total number of points to be calculated: N_end = N + N_start

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -264,11 +264,11 @@ class PlotImpz_UI(QWidget):
         self.win_viewer.hide()
 
         self.lbl_fx_range = QLabel(to_html("FX Range:", frmt='b'))
-        self.but_fx_range_x = QCheckBox("X", objectName="but_fx_range_x")
-        self.but_fx_range_x.setToolTip(
+        self.chk_fx_range_x = QCheckBox("X", objectName="chk_fx_range_x")
+        self.chk_fx_range_x.setToolTip(
              "<span>Display stimulus fixpoint range (---).</span>")
-        self.but_fx_range_y = QCheckBox("Y", objectName="but_fx_range_y")
-        self.but_fx_range_y.setToolTip(
+        self.chk_fx_range_y = QCheckBox("Y", objectName="chk_fx_range_y")
+        self.chk_fx_range_y.setToolTip(
              "<span>Display response fixpoint range (-.-).</span>")
 
         layH_ctrl_run = QHBoxLayout()
@@ -292,8 +292,8 @@ class PlotImpz_UI(QWidget):
         layH_ctrl_run.addWidget(self.qfft_win_select)
         layH_ctrl_run.addSpacing(20)
         layH_ctrl_run.addWidget(self.lbl_fx_range)
-        layH_ctrl_run.addWidget(self.but_fx_range_x)
-        layH_ctrl_run.addWidget(self.but_fx_range_y)
+        layH_ctrl_run.addWidget(self.chk_fx_range_x)
+        layH_ctrl_run.addWidget(self.chk_fx_range_y)
         layH_ctrl_run.addStretch(10)
 
         # layH_ctrl_run.setContentsMargins(*params['wdg_margins'])

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -171,7 +171,7 @@ class PlotImpz_UI(QWidget):
         # ----------- ---------------------------------------------------
         # Run control widgets
         # ---------------------------------------------------------------
-        self.but_auto_run = PushButton(" Auto", objectName="but_auto_run")
+        self.but_auto_run = PushButton(self, "Auto", objectName="but_auto_run")
         self.but_auto_run.setToolTip("<span>Update response automatically when "
                                      "parameters have been changed.</span>")
         self.but_auto_run.setCheckable(True)
@@ -348,7 +348,7 @@ class PlotImpz_UI(QWidget):
         line1 = QVLine()
         line2 = QVLine(width=5)
 
-        self.but_log_time = PushButton(" dB", objectName="but_log_time")
+        self.but_log_time = PushButton(self, "dB", objectName="but_log_time")
         self.but_log_time.setToolTip(
             "<span>Logarithmic scale for y-axis.</span>")
 
@@ -368,7 +368,7 @@ class PlotImpz_UI(QWidget):
                                            "i.e. scale by f_S</span>")
         self.chk_byfs_spgr_time.setChecked(True)
 
-        self.but_log_spgr_time = PushButton("dB", objectName="but_log_spgr")
+        self.but_log_spgr_time = PushButton(self, "dB", objectName="but_log_spgr")
         self.but_log_spgr_time.setMaximumWidth(qtext_width(text=" dB"))
         self.but_log_spgr_time.setToolTip(
             "<span>Logarithmic scale for spectrogram.</span>")
@@ -507,7 +507,7 @@ class PlotImpz_UI(QWidget):
         self.cmb_plt_freq_resp.setToolTip(
             "<span>Plot style for response.</span>")
 
-        self.but_log_freq = PushButton("dB", objectName="but_log_freq")
+        self.but_log_freq = PushButton(self, text="dB", objectName="but_log_freq")
         self.but_log_freq.setToolTip(
             "<span>Logarithmic scale for y-axis.</span>")
         self.but_log_freq.setChecked(True)
@@ -546,12 +546,12 @@ class PlotImpz_UI(QWidget):
         self.but_freq_norm_impz.setChecked(True)
         self.but_freq_norm_impz.setObjectName("freq_norm_impz")
 
-        self.but_freq_show_info = PushButton(" Info ", objectName="but_show_info_freq")
+        self.but_freq_show_info = PushButton(text="Info", objectName="but_show_info_freq")
         self.but_freq_show_info.setToolTip(
             "<span>Show signal power in legend.</span>")
         self.but_freq_show_info.setChecked(False)
 
-        self.but_freq_index_k = PushButtonRT(self, text = " <i>k</i> ", objectName="but_show_index_k")
+        self.but_freq_index_k = PushButtonRT(self, text = "<i>k</i>", objectName="but_show_index_k")
         self.but_freq_index_k.setToolTip(
             "<span>Show FFT indices instead of frequencies.</span>")
         self.but_freq_index_k.setCheckable(True)

--- a/pyfda/plot_widgets/plot_impz_ui.py
+++ b/pyfda/plot_widgets/plot_impz_ui.py
@@ -174,7 +174,7 @@ class PlotImpz_UI(QWidget):
         self.but_auto_run = PushButton(" Auto", objectName="but_auto_run")
         self.but_auto_run.setToolTip("<span>Update response automatically when "
                                      "parameters have been changed.</span>")
-        # self.but_auto_run.setCheckable(True)
+        self.but_auto_run.setCheckable(True)
         self.but_auto_run.setChecked(True)
 
         but_height = self.but_auto_run.sizeHint().height()
@@ -399,8 +399,8 @@ class PlotImpz_UI(QWidget):
             "<span>Minimum display value for time and spectrogram plots with log. scale."
             "</span>")
         self.lbl_log_bottom_time.setVisible(
-            self.but_log_time.isChecked() or
-            ((self.plt_time_spgr != "none") and self.but_log_spgr_time.isChecked()))
+            self.but_log_time.checked or
+            ((self.plt_time_spgr != "none") and self.but_log_spgr_time.checked))
         self.led_log_bottom_time.setVisible(
             self.lbl_log_bottom_time.isVisible())
 
@@ -516,15 +516,15 @@ class PlotImpz_UI(QWidget):
         self.but_log_freq.setChecked(True)
 
         self.lbl_log_bottom_freq = QLabel(to_html("min =", frmt='bi'), self)
-        self.lbl_log_bottom_freq.setVisible(self.but_log_freq.isChecked())
+        self.lbl_log_bottom_freq.setVisible(self.but_log_freq.checked)
         self.led_log_bottom_freq = QLineEdit(self)
         self.led_log_bottom_freq.setText(str(self.bottom_f))
         self.led_log_bottom_freq.setMaximumWidth(qtext_width(N_x=8))
         self.led_log_bottom_freq.setToolTip(
             "<span>Minimum display value for log. scale.</span>")
-        self.led_log_bottom_freq.setVisible(self.but_log_freq.isChecked())
+        self.led_log_bottom_freq.setVisible(self.but_log_freq.checked)
 
-        if not self.but_log_freq.isChecked():
+        if not self.but_log_freq.checked:
             self.bottom_f = 0
 
         self.cmb_freq_display = QComboBox(self, objectName="cmb_re_im_freq")
@@ -719,7 +719,7 @@ class PlotImpz_UI(QWidget):
         Show / hide FFT widget depending on the state of the corresponding button
         When widget is shown, trigger an update of the window function.
         """
-        if self.but_fft_wdg.isChecked():
+        if self.but_fft_wdg.checked:
             self.win_viewer.show()
             self.emit({'view_changed': 'fft_win_type'}, sig_name='sig_tx_fft')
         else:

--- a/pyfda/plot_widgets/plot_phi.py
+++ b/pyfda/plot_widgets/plot_phi.py
@@ -214,7 +214,7 @@ class Plot_Phi(QWidget):
         set_fil_dict(['plt_phiLabel'], y_str)
         set_fil_dict(['plt_phiUnit'], self.unitPhi)
 
-        if self.but_wrap.isChecked():
+        if self.but_wrap.checked:
             phi_plt = np.angle(H) * scale
         else:
             phi_plt = np.unwrap(np.angle(H)) * scale

--- a/pyfda/plot_widgets/plot_phi.py
+++ b/pyfda/plot_widgets/plot_phi.py
@@ -89,7 +89,7 @@ class Plot_Phi(QWidget):
         self.cmbUnitsPhi.setCurrentIndex(0)
         self.cmbUnitsPhi.setSizeAdjustPolicy(QComboBox.AdjustToContents)
 
-        self.but_wrap = PushButton("wrapped ")
+        self.but_wrap = PushButton(self, "wrapped")
         self.but_wrap.setToolTip("Plot phase wrapped to +/- pi")
 
         layHControls = QHBoxLayout()

--- a/pyfda/plot_widgets/plot_pz.py
+++ b/pyfda/plot_widgets/plot_pz.py
@@ -128,7 +128,7 @@ class Plot_PZ(QWidget):
         self.ledBottom.setMaximumWidth(qtext_width(N_x=8))
         self.ledBottom.setToolTip("Minimum display value.")
         self.lblBottomdB = QLabel("dB", self)
-        self.lblBottomdB.setVisible(self.but_log.isChecked())
+        self.lblBottomdB.setVisible(self.but_log.checked)
 
         self.lblTop = QLabel(to_html("Top =", frmt='bi'), self)
         self.ledTop = QLineEdit(self, objectName="ledTop")
@@ -136,7 +136,7 @@ class Plot_PZ(QWidget):
         self.ledTop.setToolTip("Maximum display value.")
         self.ledTop.setMaximumWidth(qtext_width(N_x=8))
         self.lblTopdB = QLabel("dB", self)
-        self.lblTopdB.setVisible(self.but_log.isChecked())
+        self.lblTopdB.setVisible(self.but_log.checked)
 
         self.but_fir_poles = PushButton(" FIR Poles ")
         self.but_fir_poles.setChecked(True)
@@ -205,7 +205,7 @@ class Plot_PZ(QWidget):
         """
         # clicking but_log triggered the slot or initialization
         if self.sender() is None or self.sender().objectName() == 'but_log':
-            if self.but_log.isChecked():
+            if self.but_log.checked:
                 self.ledBottom.setText(str(self.zmin_dB))
                 self.zmax_dB = np.round(20 * np.log10(self.zmax), 2)
                 self.ledTop.setText(str(self.zmax_dB))
@@ -215,7 +215,7 @@ class Plot_PZ(QWidget):
                 self.ledTop.setText(str(self.zmax))
 
         else:  # finishing a lineEdit field triggered the slot
-            if self.but_log.isChecked():
+            if self.but_log.checked:
                 self.zmin_dB = safe_eval(
                     self.ledBottom.text(), self.zmin_dB, return_type='float')
                 self.ledBottom.setText(str(self.zmin_dB))
@@ -256,10 +256,10 @@ class Plot_PZ(QWidget):
         contour = qget_cmb_box(self.cmb_overlay) in {"contour", "contourf"}
         self.ledBottom.setVisible(contour)
         self.lblBottom.setVisible(contour)
-        self.lblBottomdB.setVisible(contour and self.but_log.isChecked())
+        self.lblBottomdB.setVisible(contour and self.but_log.checked)
         self.ledTop.setVisible(contour)
         self.lblTop.setVisible(contour)
-        self.lblTopdB.setVisible(contour and self.but_log.isChecked())
+        self.lblTopdB.setVisible(contour and self.but_log.checked)
 
         if True:
             self.init_axes()
@@ -279,7 +279,7 @@ class Plot_PZ(QWidget):
 
         [z, p, k] = self.zplane(
             z=zpk[0], p=zpk[1], k=zpk[2], plt_ax=self.ax,
-            plt_poles=self.but_fir_poles.isChecked() or fb.fil[0]['ft'] == 'IIR',
+            plt_poles=self.but_fir_poles.checked or fb.fil[0]['ft'] == 'IIR',
             mps=p_marker[0], mpc=p_marker[1], mzs=z_marker[0], mzc=z_marker[1])
 
         self.ax.xaxis.set_minor_locator(AutoMinorLocator())  # enable minor ticks
@@ -512,14 +512,14 @@ class Plot_PZ(QWidget):
             np.arange(yl[0], yl[1], 0.01))
         z = x + 1j*y  # create coordinate grid for complex plane
 
-        if self.but_log.isChecked():
+        if self.but_log.checked:
             H_max = self.zmax_dB
             H_min = self.zmin_dB
         else:
             H_max = self.zmax
             H_min = self.zmin
         Hmag = H_mag(fb.fil[0]['ba'][0], fb.fil[0]['ba'][1], z, H_max, H_min=H_min,
-                     log=self.but_log.isChecked())
+                     log=self.but_log.checked)
 
         if overlay == "contour":
             self.ax.contour(x, y, Hmag, 20, alpha=0.5, cmap=self.cmap)
@@ -552,7 +552,7 @@ class Plot_PZ(QWidget):
         ba = fb.fil[0]['ba']
         w, H = sig.freqz(ba[0], ba[1], worN=params['N_FFT'], whole=True)
         H = np.abs(H)
-        if self.but_log.isChecked():
+        if self.but_log.checked:
             H = np.clip(np.log10(H), -6, None)  # clip to -120 dB
             H = H - np.max(H)  # shift scale to H_min ... 0
             H = 1 + (r-1) * (1 + H / abs(np.min(H)))  # scale to 1 ... r

--- a/pyfda/plot_widgets/plot_pz.py
+++ b/pyfda/plot_widgets/plot_pz.py
@@ -107,7 +107,7 @@ class Plot_PZ(QWidget):
         qcmb_box_populate(
             self.cmb_overlay, self.cmb_overlay_items, self.cmb_overlay_default)
 
-        self.but_log = PushButton(" Log.", objectName="but_log")
+        self.but_log = PushButton(self, "Log.", objectName="but_log")
         self.but_log.setChecked(True)
         self.but_log.setToolTip("<span>Log. scale for overlays.</span>")
 
@@ -138,7 +138,7 @@ class Plot_PZ(QWidget):
         self.lblTopdB = QLabel("dB", self)
         self.lblTopdB.setVisible(self.but_log.checked)
 
-        self.but_fir_poles = PushButton(" FIR Poles ")
+        self.but_fir_poles = PushButton(self, "FIR Poles")
         self.but_fir_poles.setChecked(True)
         self.but_fir_poles.setToolTip("<span>Show FIR poles at the origin.</span>")
 

--- a/pyfda/plot_widgets/tran/plot_tran_stim.py
+++ b/pyfda/plot_widgets/tran/plot_tran_stim.py
@@ -115,17 +115,17 @@ class Plot_Tran_Stim(QWidget):
                 self.title_str = self.ui.chirp_type.capitalize() + ' Chirp Stimulus'
             # ------------------------------------------------------------------
             elif self.ui.stim == "triang":
-                if self.ui.but_stim_bl.isChecked():
+                if self.ui.but_stim_bl.checked:
                     self.title_str = r'Bandlim. Triangular Stimulus'
                 else:
                     self.title_str = r'Triangular Stimulus'
             elif self.ui.stim == "saw":
-                if self.ui.but_stim_bl.isChecked():
+                if self.ui.but_stim_bl.checked:
                     self.title_str = r'Bandlim. Sawtooth Stimulus'
                 else:
                     self.title_str = r'Sawtooth Stimulus'
             elif self.ui.stim == "rect_per":
-                if self.ui.but_stim_bl.isChecked():
+                if self.ui.but_stim_bl.checked:
                     self.title_str = r'Bandlimited Rect. Stimulus'
                 else:
                     self.title_str = r'Rect. Stimulus'
@@ -361,7 +361,7 @@ class Plot_Tran_Stim(QWidget):
                 method=self.ui.chirp_type, phi=self.rad_phi1)
         # ----------------------------------------------------------------------
         elif self.ui.stim == "triang":
-            if self.ui.but_stim_bl.isChecked():
+            if self.ui.but_stim_bl.checked:
                 if self.ui.f1 <= 0:
                     logger.warning(f"Frequency f1 needs to be > 0!")
                     return None
@@ -371,7 +371,7 @@ class Plot_Tran_Stim(QWidget):
                     2*pi * n * self.ui.f1 + self.rad_phi1, width=0.5)
         # ----------------------------------------------------------------------
         elif self.ui.stim == "saw":
-            if self.ui.but_stim_bl.isChecked():
+            if self.ui.but_stim_bl.checked:
                 if self.ui.f1 <= 0:
                     logger.warning(f"Frequency f1 needs to be > 0!")
                     return None
@@ -380,7 +380,7 @@ class Plot_Tran_Stim(QWidget):
                 x[frm_slc] = self.ui.A1 * sig.sawtooth(2*pi * n * self.ui.f1 + self.rad_phi1)
         # ----------------------------------------------------------------------
         elif self.ui.stim == "rect_per":
-            if self.ui.but_stim_bl.isChecked():
+            if self.ui.but_stim_bl.checked:
                 if self.ui.f1 <= 0:
                     logger.warning(f"Frequency f1 needs to be > 0!")
                     return None
@@ -406,7 +406,7 @@ class Plot_Tran_Stim(QWidget):
                 self.ui.A2 * np.sin(2*pi * n * self.ui.f2 + self.rad_phi2))
         # ----------------------------------------------------------------------
         elif self.ui.stim == "pwm":
-            if self.ui.but_stim_bl.isChecked():
+            if self.ui.but_stim_bl.checked:
                 if self.ui.f1 <= 0:
                     logger.warning(f"Frequency f1 needs to be > 0!")
                     return None

--- a/pyfda/plot_widgets/tran/plot_tran_stim.py
+++ b/pyfda/plot_widgets/tran/plot_tran_stim.py
@@ -95,7 +95,7 @@ class Plot_Tran_Stim(QWidget):
                 self.title_str = r'Rect Impulse'
             # ------------------------------------------------------------------
             elif self.ui.stim == "step":
-                if self.ui.chk_step_err.isChecked():
+                if self.ui.but_step_err.checked:
                     self.title_str = r'Settling Error $\epsilon$'
                     self.H_str = r'$h_{\epsilon, \infty} - h_{\epsilon}[n]$'
                 else:

--- a/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
+++ b/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
@@ -288,12 +288,13 @@ class Plot_Tran_Stim_UI(QWidget):
             self.cmb_stim_modulation_item)
 
         # -------------------------------------
-        self.chk_step_err = QPushButton("Error", objectName="stim_step_err")
-        self.chk_step_err.setToolTip(
+        self.but_step_err = PushButton(
+            text="Error", objectName="stim_step_err")
+        self.but_step_err.setToolTip(
             "<span>Display the step response error.</span>")
-        self.chk_step_err.setMaximumWidth(qtext_width(text="Error "))
-        self.chk_step_err.setCheckable(True)
-        self.chk_step_err.setChecked(False)
+        # self.but_step_err.setMaximumWidth(qtext_width(text="Error "))
+        self.but_step_err.setCheckable(True)
+        self.but_step_err.setChecked(False)
         #
         self.but_file_io = PushButton("<", checkable=False)
         self.but_file_io.setToolTip(
@@ -321,7 +322,7 @@ class Plot_Tran_Stim_UI(QWidget):
         layHCmbStim.addWidget(self.but_stim_bl)
         layHCmbStim.addWidget(self.lblStimPar1)
         layHCmbStim.addWidget(self.ledStimPar1)
-        layHCmbStim.addWidget(self.chk_step_err)
+        layHCmbStim.addWidget(self.but_step_err)
 
         self.lblDC = QLabel(to_html("DC =", frmt='bi'), self)
         self.ledDC = QLineEdit(self, objectName="stimDC")
@@ -572,7 +573,7 @@ class Plot_Tran_Stim_UI(QWidget):
         # ----------------------------------------------------------------------
         # --- stimulus control ---
         self.but_stim_bl.clicked.connect(self._enable_stim_widgets)
-        self.chk_step_err.clicked.connect(self._enable_stim_widgets)
+        self.but_step_err.clicked.connect(self._enable_stim_widgets)
         self.cmbStimulus.currentIndexChanged.connect(self._enable_stim_widgets)
 
         self.cmb_stim_noise.currentIndexChanged.connect(self._update_noi)
@@ -827,7 +828,7 @@ class Plot_Tran_Stim_UI(QWidget):
         self.lblDC.setVisible("dc" in stim_wdg)
         self.ledDC.setVisible("dc" in stim_wdg)
 
-        self.chk_step_err.setVisible(self.stim == "step")
+        self.but_step_err.setVisible(self.stim == "step")
 
         self.lblStimPar1.setVisible("par1" in stim_wdg)
         self.ledStimPar1.setVisible("par1" in stim_wdg)

--- a/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
+++ b/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
@@ -295,7 +295,7 @@ class Plot_Tran_Stim_UI(QWidget):
         self.but_step_err.setCheckable(True)
         self.but_step_err.setChecked(False)
         #
-        self.but_file_io = PushButton("<", checkable=False)
+        self.but_file_io = PushButton(self, "<", checkable=False)
         self.but_file_io.setToolTip(
             "<span>Use file length as number of data points.</span>")
         self.lbl_file_io = QLabel(to_html("&nbsp;File IO", frmt='bi'))

--- a/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
+++ b/pyfda/plot_widgets/tran/plot_tran_stim_ui.py
@@ -255,8 +255,7 @@ class Plot_Tran_Stim_UI(QWidget):
         self.ledStimPar1.setText("0.5")
         self.ledStimPar1.setToolTip("Duty Cycle, 0 ... 1")
 
-        self.but_stim_bl = QPushButton(self, objectName="stim_bl")
-        self.but_stim_bl.setText("BL")
+        self.but_stim_bl = PushButton(self, text="BL", objectName="stim_bl")
         self.but_stim_bl.setToolTip(
             "<span>Bandlimit the signal to the Nyquist "
             "frequency to avoid aliasing. However, this is much slower "

--- a/pyfda/plot_widgets/tran/tran_io.py
+++ b/pyfda/plot_widgets/tran/tran_io.py
@@ -158,7 +158,7 @@ class Tran_IO(QWidget):
 
         The sampling frequency needs to integer and at least 1.
         """
-        if not self.ui.but_f_s_wav_auto.isChecked() or f_s_wav is None:
+        if not self.ui.but_f_s_wav_auto.checked or f_s_wav is None:
             f_s_wav = self.ui.led_f_s_wav.text()
 
         self.f_s_wav = max(safe_eval(f_s_wav, alt_expr=self.f_s_wav,
@@ -371,7 +371,7 @@ class Tran_IO(QWidget):
             self.x_file = data
 
         self.emit({'data_changed': 'file_io'})
-        if self.ui.but_f_s_wav_auto.isChecked():
+        if self.ui.but_f_s_wav_auto.checked:
             fb.fil[0]['f_S'] = self.f_s_file
             fb.fil[0]['freq_specs_unit'] = 'Hz'
             self.emit({'view_changed': 'f_S'})

--- a/pyfda/plot_widgets/tran/tran_io.py
+++ b/pyfda/plot_widgets/tran/tran_io.py
@@ -9,16 +9,16 @@
 """
 Widget for loading and storing stimulus data from / to transient plotting widget
 """
-from pyfda.libs.compat import Qt, QWidget, pyqtSignal, QVBoxLayout, QDialog
+from pyfda.libs.compat import Qt, QWidget, pyqtSignal, QVBoxLayout, QDialog, QPushButton
 import numpy as np
 
 import pyfda.libs.pyfda_io_lib as io
 import pyfda.filterbroker as fb
 import pyfda.libs.pyfda_dirs as dirs
 
-from pyfda.libs.pyfda_lib import safe_eval, pprint_log, np_shape
+from pyfda.libs.pyfda_lib import safe_eval, pprint_log
 from pyfda.libs.pyfda_qt_lib import (
-    emit, qstyle_widget, qget_cmb_box, qset_cmb_box, qwindow_stay_on_top)
+    emit, qstyle_widget, qget_cmb_box, qset_cmb_box, qwindow_stay_on_top, PushButton)
 from pyfda.libs.csv_option_box import CSV_option_box
 
 from pyfda.pyfda_rc import params  # FMT string for QLineEdit fields, e.g. '{:.3g}'
@@ -54,8 +54,8 @@ class QFileDialogPlus(QDialog):
         """ initialize the User Interface """
         self.setWindowTitle("CSV Options")
 
-        butClose = QPushButton(self)
-        butClose.setText("Close")
+        butClose = QPushButton(self, text="Close")
+        # butClose.setText("Close")
 
         layVMain = QVBoxLayout()
         # layVMain.setAlignment(Qt.AlignTop) # only affects first widget (intended here)
@@ -384,7 +384,7 @@ class Tran_IO(QWidget):
         """
         if dirs.csv_options_handle is None:
             # no handle to the window? Create a new instance!
-            if self.ui.but_csv_options.isChecked():
+            if self.ui.but_csv_options.checked:
                 # Important: Handle to window must be class attribute otherwise it (and
                 # the attached window) is deleted immediately when it goes out of scope
                 dirs.csv_options_handle = CSV_option_box(self)

--- a/pyfda/plot_widgets/tran/tran_io_ui.py
+++ b/pyfda/plot_widgets/tran/tran_io_ui.py
@@ -115,7 +115,7 @@ class Tran_IO_UI(QWidget):
         # ----------------------------------------------------------------------
 
         # ----------- LOAD ------------------------------------------------------------
-        self.but_select = PushButton("Select", checkable=False, objectName="large")
+        self.but_select = PushButton(self, "Select", checkable=False, objectName="large")
         self.but_select.setSizePolicy(QSizePolicy.Expanding,
                                     QSizePolicy.Expanding)
         self.but_select.setToolTip(
@@ -164,7 +164,7 @@ class Tran_IO_UI(QWidget):
         self.lbl_wordlength = QLabel(to_html("W =", frmt="bi"))
         self.lbl_wordlength_value = QLabel("None")
 
-        self.but_scale_to = PushButton("Scale to")
+        self.but_scale_to = PushButton(self, "Scale to")
         self.but_scale_to.setToolTip(
             self.tr("<span>When activated, scale maximum of data to the value below "
                     "before saving and after loading.</span>"))
@@ -181,7 +181,7 @@ class Tran_IO_UI(QWidget):
             "<span>Select CSV format and whether "
             "to copy to/from clipboard or file.</span>")
 
-        self.but_int_as_float = PushButton("Int2Float ")
+        self.but_int_as_float = PushButton(self, "Int2Float")
         self.but_int_as_float.setChecked(True)
         self.but_int_as_float.setToolTip(
             "<span>Represent <i>W</i> bit integer WAV formats as float when importing "
@@ -399,7 +399,7 @@ if __name__ == "__main__":
     mainw = Tran_IO_UI()
 
     layVMain = QVBoxLayout()
-    layVMain.addWidget(mainw.wdg_stim)
+    layVMain.addWidget(mainw.wdg_top)
 
     mainw.setLayout(layVMain)
     app.setActiveWindow(mainw)

--- a/pyfda/plot_widgets/tran/tran_io_ui.py
+++ b/pyfda/plot_widgets/tran/tran_io_ui.py
@@ -11,13 +11,13 @@ Create the UI for the Tran_IO class
 """
 from PyQt5.QtWidgets import QSizePolicy
 from pyfda.libs.compat import (
-    QWidget, QComboBox, QLineEdit, QLabel, QPushButton, QPushButtonRT, QLineEdit, QFrame,
+    QWidget, QComboBox, QLineEdit, QLabel, QPushButton, QLineEdit, QFrame,
     QHBoxLayout, QVBoxLayout, QGridLayout, QIcon)
 
 from pyfda.libs.pyfda_lib import to_html
 from pyfda.libs.pyfda_qt_lib import (
-    QVLine, PushButton, qget_cmb_box, qcmb_box_populate, qcmb_box_add_items,
-    qcmb_box_del_item, qtext_width)
+    QVLine, PushButton, PushButtonRT, qget_cmb_box, qcmb_box_populate,
+    qcmb_box_add_items, qcmb_box_del_item, qtext_width)
 from pyfda.pyfda_rc import params  # FMT string for QLineEdit fields, e.g. '{:.3g}'
 
 import logging
@@ -190,7 +190,8 @@ class Tran_IO_UI(QWidget):
         layH_file_fmt_options.addWidget(self.but_csv_options)
         layH_file_fmt_options.addWidget(self.but_int_as_float)
 
-        self.but_f_s_wav_auto = QPushButtonRT(self, "<b>Auto <i>f<sub>S</sub></i></b>", margin=5)
+        self.but_f_s_wav_auto = PushButtonRT(
+            self, text="<b>Auto <i>f<sub>S</sub></i></b>", margin=5)
         self.but_f_s_wav_auto.setCheckable(True)
         self.but_f_s_wav_auto.setChecked(True)
         self.but_f_s_wav_auto.setToolTip(


### PR DESCRIPTION
"checked" state creates grey dots on top of the push button layout which can only be avoided by defining the QSS border attribute which destroys the default layout. Additionally, the checked state cannot be used as a selector for cascading style sheets.

Hence, two new widgets PushButton and PushButtonRT (for rich text) have been created which operate with the property "state" which can be set to "highlight" for an activated look.