### PR TITLE
Fix windowed FIR to use numtaps

### DIFF
--- a/pyfda/filter_widgets/firwin.py
+++ b/pyfda/filter_widgets/firwin.py
@@ -531,8 +531,9 @@ class Firwin(QWidget):
         self._get_params()
         if not self._test_n():
             return -1
-        self._save(self.firwin(self.N, fb_get('F_C'), nyq=0.5,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+        numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps
+        self._save(self.firwin(numtaps, fb_get('F_C'), nyq=0.5,
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         return 0
 
     def HPmin(self) -> int:
@@ -555,8 +556,9 @@ class Firwin(QWidget):
         self.N = round_odd(self.N)  # enforce odd order
         if not self._test_n():
             return -1
-        self._save(self.firwin(self.N, fb_get('F_C'), pass_zero=False, nyq=0.5,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+        numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps
+        self._save(self.firwin(numtaps, fb_get('F_C'), pass_zero=False, nyq=0.5,
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         return 0
 
     # For BP and BS, F_PB and F_SB have two elements each
@@ -581,9 +583,10 @@ class Firwin(QWidget):
         self._get_params()
         if not self._test_n():
             return -1
-        self._save(self.firwin(self.N, [fb_get('F_C'), fb_get('F_C2')], nyq=0.5,
+        numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps
+        self._save(self.firwin(numtaps, [fb_get('F_C'), fb_get('F_C2')], nyq=0.5,
                                pass_zero=False,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         return 0
 
     def BSmin(self) -> int:
@@ -608,8 +611,9 @@ class Firwin(QWidget):
         self.N = round_odd(self.N)  # enforce odd order
         if not self._test_n():
             return -1
-        self._save(self.firwin(self.N, [fb_get('F_C'), fb_get('F_C2')],
-                               window=self.qfft_win_select.calc_window(self.N, sym=True),
+        numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps
+        self._save(self.firwin(numtaps, [fb_get('F_C'), fb_get('F_C2')],
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True),
                                pass_zero=True, nyq=0.5))
         return 0
 

--- a/pyfda/filter_widgets/firwin.py
+++ b/pyfda/filter_widgets/firwin.py
@@ -44,7 +44,7 @@ from pyfda.filterbroker import fb_get, fb_set
 import pyfda.libs.pyfda_dirs as dirs
 from pyfda.libs.compat import (QWidget, pyqtSignal, QComboBox, QIcon, QSize,
                                QHBoxLayout, QVBoxLayout)
-from pyfda.libs.pyfda_lib import round_odd, pprint_log
+from pyfda.libs.pyfda_lib import round_even, pprint_log
 from pyfda.libs.pyfda_qt_lib import popup_warning, PushButton, emit
 from pyfda.libs.pyfda_sig_lib import fil_save
 from pyfda.libs.fft_windows_cmb_box import QFFTWinCmbBox
@@ -542,7 +542,7 @@ class Firwin(QWidget):
         self._get_params()
         N = self._firwin_ord([self.F_SB, self.F_PB], [0, 1],
                              [self.A_SB, self.A_PB], alg=self.alg)
-        self.N = round_odd(N)  # enforce odd order
+        self.N = round_even(N)  # enforce even order
         if not self._test_n():
             return -1
         fb_set('F_C', (self.F_SB + self.F_PB)/2)  # average calculated F_PB and F_SB
@@ -555,7 +555,7 @@ class Firwin(QWidget):
     def HPman(self) -> int:
         """ Design a high-pass FIR filter with user-defined order using the window method."""
         self._get_params()
-        self.N = round_odd(self.N)  # enforce odd order
+        self.N = round_even(self.N)  # enforce even order
         if not self._test_n():
             return -1
         numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps
@@ -597,7 +597,7 @@ class Firwin(QWidget):
         self._get_params()
         N = remezord([self.F_PB, self.F_SB, self.F_SB2, self.F_PB2], [1, 0, 1],
                      [self.A_PB, self.A_SB, self.A_PB2], fs=1, alg=self.alg)[0]
-        self.N = round_odd(N)  # enforce odd order
+        self.N = round_even(N)  # enforce even order
         if not self._test_n():
             return -1
         fb_set('F_C', (self.F_SB + self.F_PB) / 2)  # average calculated F_PB and F_SB
@@ -612,7 +612,7 @@ class Firwin(QWidget):
     def BSman(self) -> int:
         """ Design a band-stop FIR filter with user-defined order using the window method."""
         self._get_params()
-        self.N = round_odd(self.N)  # enforce odd order
+        self.N = round_even(self.N)  # enforce even order
         if not self._test_n():
             return -1
         numtaps = self.N + 1  # UI N is order; firwin/calc_window expect numtaps

--- a/pyfda/filter_widgets/firwin.py
+++ b/pyfda/filter_widgets/firwin.py
@@ -521,8 +521,9 @@ class Firwin(QWidget):
             return -1
 
         fb_set('F_C', (self.F_SB + self.F_PB)/2)  # average calculated F_PB and F_SB
-        self._save(self.firwin(self.N, fb_get('F_C'), nyq=0.5,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+        numtaps = self.N + 1
+        self._save(self.firwin(numtaps, fb_get('F_C'), nyq=0.5,
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         fb_set('N', self.N)  # update filterbroker with calculated order
         return 0
 
@@ -545,8 +546,9 @@ class Firwin(QWidget):
         if not self._test_n():
             return -1
         fb_set('F_C', (self.F_SB + self.F_PB)/2)  # average calculated F_PB and F_SB
-        self._save(self.firwin(self.N, fb_get('F_C'), pass_zero=False, nyq=0.5,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+        numtaps = self.N + 1
+        self._save(self.firwin(numtaps, fb_get('F_C'), pass_zero=False, nyq=0.5,
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         fb_set('N', self.N)  # update filterbroker with calculated order
         return 0
 
@@ -572,9 +574,10 @@ class Firwin(QWidget):
 
         fb_set('F_C', (self.F_SB + self.F_PB)/2)  # average calculated F_PB and F_SB
         fb_set('F_C2', (self.F_SB2 + self.F_PB2)/2)
-        self._save(self.firwin(self.N, [fb_get('F_C'), fb_get('F_C2')], nyq=0.5,
+        numtaps = self.N + 1
+        self._save(self.firwin(numtaps, [fb_get('F_C'), fb_get('F_C2')], nyq=0.5,
                                pass_zero=False,
-                               window=self.qfft_win_select.calc_window(self.N, sym=True)))
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True)))
         fb_set('N', self.N)  # update filterbroker with calculated order
         return 0
 
@@ -599,8 +602,9 @@ class Firwin(QWidget):
             return -1
         fb_set('F_C', (self.F_SB + self.F_PB) / 2)  # average calculated F_PB and F_SB
         fb_set('F_C2', (self.F_SB2 + self.F_PB2) / 2)
-        self._save(self.firwin(self.N, [fb_get('F_C'), fb_get('F_C2')],
-                               window=self.qfft_win_select.calc_window(self.N, sym=True),
+        numtaps = self.N + 1
+        self._save(self.firwin(numtaps, [fb_get('F_C'), fb_get('F_C2')],
+                               window=self.qfft_win_select.calc_window(numtaps, sym=True),
                                pass_zero=True, nyq=0.5))
         fb_set('N', self.N)  # update filterbroker with calculated order
         return 0


### PR DESCRIPTION
When the windowed FIR filter order was selected manually, it decremented each design run.